### PR TITLE
Add a basic dependabot configuration and dependacheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Keep track of all github actions.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: docker
+    directory: "/tools/dplsh"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: docker
+    directory: "/tools/plantuml"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependacheck.yaml
+++ b/.github/workflows/dependacheck.yaml
@@ -1,0 +1,15 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+name: Check that dependabot is set up properly
+jobs:
+  dependacheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that images are checked by dependabot
+        run: |
+          ./tools/dependacheck/dependacheck

--- a/tools/dependacheck/README.md
+++ b/tools/dependacheck/README.md
@@ -1,0 +1,6 @@
+# Dependacheck
+
+A script that checks that the a dependabot configuration contains entries for
+all relevant sources for dependencies.
+
+The script currently supports Dockerfiles.

--- a/tools/dependacheck/dependacheck
+++ b/tools/dependacheck/dependacheck
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+SKIPLIST=""
+
+while getopts ":s:h" opt; do
+    case ${opt} in
+        s )
+            SKIPLIST=$OPTARG
+            ;;
+        h )
+            echo "Usage: dependacheck [OPTION]..."
+            echo "Finds Dockerfiles and checks that they're mentioned in depentabot config."
+            echo
+            echo "Options:"
+            echo "  -s    Comma seperated list of paths to skip"
+            echo "  -h    This help text"
+            exit
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid Option: -$OPTARG requires an argument" 1>&2
+            exit 1
+            ;;
+    esac
+done
+
+# Use sed to strip the leading dot.
+DOCKER_FILES=$(find . -name Dockerfile | sed -e 's/^\.//')
+
+EXIT_CODE=0
+
+echo "Checking that depentabot it configured with all Dockerfiles"
+
+for FILE in $DOCKER_FILES; do
+    DIR=$(dirname $FILE)
+    echo -n $DIR
+    if [[ ",$SKIPLIST," = *,$DIR,* ]]; then
+        echo " [SKIPPED]"
+        continue
+    fi
+    if grep -q "directory: \"$DIR\"" .github/dependabot.yml; then
+        echo " [OK]"
+    else
+        echo " [Missing Dependabot configuration for Dockerfile]"
+        EXIT_CODE=1
+    fi
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
#### What does this PR do?
Dependacheck will detect if we're adding Dockerfiles that has not been added to the dependabot configuration.

#### How should this be manually tested?
Dependabot should complain if it detects an invalid configuration.

#### What are the relevant tickets?
DDFDPDEL-57

