### PR TITLE
Ensure we can see the remote IP in the Ingress-Nginx logs

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -2,13 +2,16 @@ controller:
   watchIngressWithoutClass: true
   config:
     # Setup a json-based access-log.
-    log-format-upstream: '{"time": "$time_iso8601", "remote_addr": "$proxy_protocol_addr", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$req_id",
+    # We use $proxy_add_x_forwarded_for as remote_addr as we're behind a load-
+    # balancer with externalTrafficPolicy=Local: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections
+    log-format-upstream: '{"time": "$time_iso8601", "remote_addr": "$proxy_add_x_forwarded_for", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$req_id",
       "bytes_sent": $bytes_sent, "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol",
       "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer",
       "http_user_agent": "$http_user_agent" }'
   replicaCount: 2
   service:
     loadBalancerIP: "${INGRESS_IP}"
+    externalTrafficPolicy: "Local"
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: "false"
       service.beta.kubernetes.io/azure-load-balancer-resource-group: "${RESOURCE_GROUP}"


### PR DESCRIPTION
#### What does this PR do?
Due to how the load-balancer is set up pr default in kube, we do not
get the clients real ip out of the box. This commit reconfigures the
load-balancer to make the remote ip visible, and adjust the logs to use
another field to log the ip.

See https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections
for some more details on the issue

#### Should this be tested by the reviewer and how?
apply the change to a running service to see the result.
