### PR TITLE
Disable Lagoon services that we do not use

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
@@ -14,6 +14,18 @@ s3BAASSecretAccessKey: none
 imageTag: v2.0.0-rc.9
 registry: none.com
 
+# Disabled services:
+logs2email:
+  enabled: false
+logs2microsoftteams:
+  enabled: false
+logs2rocketchat:
+  enabled: false
+logs2slack:
+  enabled: false
+logs2webhook:
+  enabled: false
+
 api:
   ingress:
     enabled: true


### PR DESCRIPTION
#### What does this PR do?
Lagoon ships with a lot of services we do not need.

https://github.com/uselagoon/lagoon-charts/tree/main/charts/lagoon-core describes how to diable lot of them.

This commit disables the services that we do not expect to use.

#### Should this be tested by the reviewer and how?
You could do a `DIFF=1 task lagoon:provision:core` to verify that the services will be diabled.

