### PR TITLE
Specify buckets for both backup and restore.

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -195,14 +195,23 @@ tasks:
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.
       desc: Install and configure the K8up backup operator
       env:
-        # As specified in the values file for the backup minio workload.
-        API_URL: http://minio-backup.minio.svc.cluster.local:9000
+        # Specify the two endpoints k8up will use for backup and restore.
+        # We specify a cluster service for backups to keep performance as
+        # good as possible.
+        BACKUP_API_URL: http://minio-backup.minio.svc.cluster.local:9000
+        # And the same endpoint now behind an Ingress as we need it to be
+        # available from a browser.
+        RESTORE_API_URL: https://backup-storage.lagoon.{{.platform_env}}.{{.global_environment_suffix}}
         # As specified in the values file for lagoon-core
         LAGOON_BACKUP_HANDLER_URL: https://backuphandler.lagoon.{{.platform_env}}.{{.global_environment_suffix}}
         K8UP_GLOBALSTATSURL: https://k8up.lagoon.{{.platform_env}}.{{.global_environment_suffix}}
-        CLIENT_ACCESS_KEY:
+        BACKUP_CLIENT_ACCESS_KEY:
           sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".backup_blob_storage_client_access_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
-        CLIENT_SECRET_KEY:
+        BACKUP_CLIENT_SECRET_KEY:
+          sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".backup_blob_storage_client_secret_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
+        RESTORE_CLIENT_ACCESS_KEY:
+          sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".backup_blob_storage_client_access_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
+        RESTORE_CLIENT_SECRET_KEY:
           sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".backup_blob_storage_client_secret_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
       cmds:
         - task/scripts/provision-k8up.sh

--- a/infrastructure/environments/dplplat01/configuration/k8up/k8up-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/k8up/k8up-values.template.yaml
@@ -2,27 +2,27 @@
 k8up:
   envVars:
    - name: BACKUP_GLOBALS3ENDPOINT
-     value: "${API_URL}"
+     value: "${BACKUP_API_URL}"
    - name: BACKUP_GLOBALS3BUCKET
-     value: ""
+     value: "backup"
    - name: BACKUP_GLOBALKEEPJOBS
      value: "1"
    - name: BACKUP_GLOBALSTATSURL
      value: "${LAGOON_BACKUP_HANDLER_URL}"
    - name: BACKUP_GLOBALACCESSKEYID
-     value: "${CLIENT_ACCESS_KEY}"
+     value: "${BACKUP_CLIENT_ACCESS_KEY}"
    - name: BACKUP_GLOBALSECRETACCESSKEY
-     value: "${CLIENT_SECRET_KEY}"
+     value: "${BACKUP_CLIENT_SECRET_KEY}"
    - name: BACKUP_BACKOFFLIMIT
      value: "2"
    - name: BACKUP_GLOBALRESTORES3BUCKET
-     value: "" # should start with `baas-*` for simpler permissions
+     value: "restore" # should start with `baas-*` for simpler permissions
    - name: BACKUP_GLOBALRESTORES3ENDPOINT
-     value: "${API_URL}"
+     value: "${RESTORE_API_URL}"
    - name: BACKUP_GLOBALRESTORES3ACCESSKEYID
-     value: "${CLIENT_ACCESS_KEY}"
+     value: "${RESTORE_CLIENT_ACCESS_KEY}"
    - name: BACKUP_GLOBALRESTORES3SECRETACCESSKEY
-     value: "${CLIENT_SECRET_KEY}"
+     value: "${RESTORE_CLIENT_SECRET_KEY}"
 
   # -- Specifies the timezone K8up is using for scheduling.
   # Empty value defaults to the timezone in which Kubernetes is deployed.

--- a/infrastructure/task/scripts/provision-k8up.sh
+++ b/infrastructure/task/scripts/provision-k8up.sh
@@ -23,9 +23,12 @@ source "$(getVersionsEnv)"
 
 # These variables are either pulled in via the environment or versions.env.
 # The credentials the client (eg. lagoon) has to present to k8up to gain access.
-verifyVariable "API_URL"
-verifyVariable "CLIENT_ACCESS_KEY"
-verifyVariable "CLIENT_SECRET_KEY"
+verifyVariable "BACKUP_API_URL"
+verifyVariable "RESTORE_API_URL"
+verifyVariable "BACKUP_CLIENT_ACCESS_KEY"
+verifyVariable "BACKUP_CLIENT_SECRET_KEY"
+verifyVariable "RESTORE_CLIENT_ACCESS_KEY"
+verifyVariable "RESTORE_CLIENT_SECRET_KEY"
 verifyVariable "K8UP_GLOBALSTATSURL"
 verifyVariable "LAGOON_BACKUP_HANDLER_URL"
 
@@ -46,7 +49,7 @@ set -e
 setupHelmRepo appuio https://charts.appuio.ch
 
 # shellcheck disable=SC2016
-envsubst '$API_URL $K8UP_GLOBALSTATSURL $CLIENT_ACCESS_KEY $CLIENT_SECRET_KEY $LAGOON_BACKUP_HANDLER_URL' \
+envsubst '$BACKUP_API_URL $RESTORE_API_URL $BACKUP_CLIENT_ACCESS_KEY $BACKUP_CLIENT_SECRET_KEY $RESTORE_CLIENT_ACCESS_KEY $RESTORE_CLIENT_SECRET_KEY $K8UP_GLOBALSTATSURL $LAGOON_BACKUP_HANDLER_URL' \
   < "${configuration_dir}/k8up/k8up-values.template.yaml" \
   > "${configuration_dir}/k8up/k8up-values.yaml"
 
@@ -60,5 +63,4 @@ helm ${diff_or_nothing} upgrade --install \
   --values "${configuration_dir}/k8up/k8up-values.yaml"
 
 echo " > Done."
-
 


### PR DESCRIPTION
#### What does this PR do?
Specify both BACKUP_GLOBALS3BUCKET and BACKUP_GLOBALRESTORES3BUCKET
to let k8up store its data in separate buckets.

We also direct k8up to use a public endpoint for storing restores so
that the file can be fetched by an end-user.

#### Should this be tested by the reviewer and how?
Verify that backups can now be downloaded. Will most likely only work for new backups.

