### PR TITLE
Document how to download and restore backups.

### DIFF
--- a/documentation/backup.md
+++ b/documentation/backup.md
@@ -1,6 +1,7 @@
 # Backup
 
 ## Site backup configuration
+
 We configure all production backups with a backup schedule that ensure that the
 site is backed up at least once a day.
 
@@ -15,13 +16,7 @@ deployed. The templates for the different site types can be found as a part
 of [dpladm](../infrastructure/dpladm).
 
 Refer to the [lagoon documentation on backups](https://docs.lagoon.sh/lagoon/using-lagoon-advanced/backups)
-for more information
+for more general information.
 
-## Retrieving backups
-Citing the [Lagoon backup documentation](https://docs.lagoon.sh/lagoon/using-lagoon-advanced/backups#retrieving-backups)
-> Backups stored in Restic will be tracked within Lagoon, and can be recovered via the "Backup" tab for each environment in the Lagoon UI.
-
-Backups can be downloaded on demand. Restoring a backup onto a running site
-is a manual process where an administrator first copies the backup into a
-site pod eg. via `kubectl cp` and then copies files into their destination and
-imports databasedumps via eg. `drush sqlc`.
+Refer to any [runbooks](runbooks) relevant to backups for operational instructions
+on eg. retrieving a backup.

--- a/documentation/runbooks/retrieve-restore-backup.md
+++ b/documentation/runbooks/retrieve-restore-backup.md
@@ -1,0 +1,163 @@
+# Retrieving backups
+
+## When to use
+
+When you wish to download an automatic backup made by Lagoon, and optionally
+restore it into an existing site.
+
+## Prerequisites
+
+* Administrative access to the site in the Lagoon UI
+* (for restore) administrative cluster-access to the site
+
+## Procedure
+
+Step overview:
+
+1. Download the backup
+2. Upload the backup to relevant pods
+3. Extract the backup.
+4. Cache clearing
+5. Cleanup
+
+While most steps are different for file and database backups, step 1 is close to
+identical for the two guides.
+
+Be aware that the guide instructs you to copy the backups to `/tmp` inside the
+cli pod. Depending on the resources available on the node `/tmp` may not have
+enough space in which case you may need to modify the `cli` deployment to add
+a temporary volume, or place the backup inside the existing `/site/default/files`
+folder.
+
+### Step 1, downloading the backup
+
+ To download the backup access the Lagoon UI and schedule the retrieval of a
+ backup. To do this,
+
+ 1. Log in to the environments Lagoon UI (consult the
+ [environment documentation](../platform-environments.md) for the url)
+ 2. Access the sites project
+ 3. Access the sites environment ("Main" for production)
+ 4. Click on the "Backups" tab
+ 5. Click on the "Retrieve" button for the backups you wish to download and/or
+    restore. Use to "Source" column to differentiate the types of backups.
+    "nginx" are backups of the sites files, while "mariadb" are backups of the
+    sites database.
+ 6. The Buttons changes to "Downloading..." when pressed, wait for them to
+    change to "Download", then click them again to download the backup
+
+### Step 2a, restore a database
+
+To restore the database we must first copy the backup into a running cli-pod
+for a site, and then import the database-dump on top of the running site.
+
+1. Copy the uncompressed mariadb sql file you want to restore into the `dpl-platform/infrastructure`
+   folder from which we will launch dplsh
+2. Launch dplsh from the infrastructure folder ([instructions](using-dplsh.md))
+   and follow the procedure below:
+
+```sh
+# 1. Authenticate against the cluster.
+$ task cluster:auth
+
+# 2. List the namespaces to identify the sites namespace
+# The namespace will be on the form <sitename>-<branchname>
+# eg "bib-rb-main" for the "main" branch for the "bib-rb" site.
+$ kubectl get ns
+
+# 3. Export the name of the namespace as SITE_NS
+# eg.
+$ export SITE_NS=bib-rb-main
+
+# 4. Copy the *mariadb.sql file to the CLI pod in the sites namespace
+# eg.
+kubectl cp \
+  -n $SITE_NS  \
+  *mariadb.sql \
+  $(kubectl -n $SITE_NS get pod -l app.kubernetes.io/instance=cli -o jsonpath="{.items[0].metadata.name}"):/tmp/database-backup.sql
+
+# 5. Have drush inside the CLI-pod import the database and clear out the backup
+kubectl exec \
+  -n $SITE_NS \
+  deployment/cli \
+  -- \
+    bash -c " \
+         echo Verifying file \
+      && test -s /tmp/database-backup.sql || (echo database-backup.sql is missing or empty && exit 1) \
+      && echo Dropping database \
+      && drush sql-drop -y \
+      && echo Importing backup \
+      && drush sqlc < /tmp/database-backup.sql \
+      && echo Clearing cache \
+      && drush cr \
+      && rm /tmp/database-backup.sql
+    "
+```
+
+### Step 2b, restore a sites files
+
+To restore backed up files into a site we must first copy the backup into a
+running cli-pod for a site, and then rsync the files on top top of the running
+site.
+
+1. Copy tar.gz file into the `dpl-platform/infrastructure` folder from which we
+   will launch dplsh
+2. Launch dplsh from the infrastructure folder ([instructions](using-dplsh.md))
+   and follow the procedure below:
+
+```sh
+# 1. Authenticate against the cluster.
+$ task cluster:auth
+
+# 2. List the namespaces to identify the sites namespace
+# The namespace will be on the form <sitename>-<branchname>
+# eg "bib-rb-main" for the "main" branch for the "bib-rb" site.
+$ kubectl get ns
+
+# 3. Export the name of the namespace as SITE_NS
+# eg.
+$ export SITE_NS=bib-rb-main
+
+# 4. Copy the files tar-ball into the CLI pod in the sites namespace
+# eg.
+kubectl cp \
+  -n $SITE_NS  \
+  backup*-nginx-*.tar.gz \
+  $(kubectl -n $SITE_NS get pod -l app.kubernetes.io/instance=cli -o jsonpath="{.items[0].metadata.name}"):/tmp/files-backup.tar.gz
+
+# 5. Replace the current files with the backup.
+# The following
+# - Verifies the backup exists
+# - Removes the existing sites/default/files
+# - Un-tars the backup into its new location
+# - Fixes permissions and clears the cache
+# - Removes the backup archive
+#
+# These steps can also be performed one by one if you want to.
+kubectl exec \
+  -n $SITE_NS \
+  deployment/cli \
+  -- \
+    bash -c " \
+         echo Verifying file \
+      && test -s /tmp/files-backup.tar.gz || (echo files-backup.tar.gz is missing or empty && exit 1) \
+      && tar ztf /tmp/files-backup.tar.gz data/nginx &> /dev/null || (echo could not verify the tar.gz file files-backup.tar && exit 1) \
+      && test -d /app/web/sites/default/files || (echo Could not find destination /app/web/sites/default/files && exit 1) \
+      && echo Removing existing sites/default/files \
+      && rm -fr /app/web/sites/default/files \
+      && echo Unpacking backup \
+      && mkdir -p /app/web/sites/default/files \
+      && tar --strip 2 --gzip --extract --file /tmp/files-backup.tar.gz --directory /app/web/sites/default/files data/nginx \
+      && echo Fixing permissions \
+      && chmod -R 777 /app/web/sites/default/files \
+      && echo Clearing cache \
+      && drush cr \
+      && echo Deleting backup archive \
+      && rm /tmp/files-backup.tar.gz
+    "
+
+#  NOTE: In some situations some files in /app/web/sites/default/files might
+#  be locked by running processes. In that situations delete all the files you
+#  can from /app/web/sites/default/files manually, and then repeat the step
+#  above skipping the removal of /app/web/sites/default/files
+```

--- a/documentation/runbooks/using-dplsh.md
+++ b/documentation/runbooks/using-dplsh.md
@@ -1,0 +1,46 @@
+# Using the DPL Shell
+
+The Danish Public Libraries Shell is a container-based shell used by platform-
+operators for all cli operations.
+
+## When to use
+
+Whenever you perform any administrative actions on the platform. If you want
+to know more about the shell itself? Refer to [tools/dplsh](../../tools/dplsh).
+
+## Prerequisites
+
+* Docker
+* [jq](https://stedolan.github.io/jq/download/)
+* Bash 4 or newer
+* An authorized Azure `az` cli. The version should match the version found in
+  `FROM mcr.microsoft.com/azure-cli:version` in the [dplsh Dockerfile](../../tools/dplsh/Dockerfile).
+  You can choose to authorize the az cli from within dplsh, but your session
+  will only last as long as the shell-session.
+* `dplsh.sh` symlinked into your path as `dplsh`, see [Launching the Shell](../../tools/dplsh/README.md#launching-the-shell) (optional, but assumed below)
+
+## Procedure
+
+```sh
+# Launch dplsh.
+$ cd infrastructure
+$ dplsh
+
+# 1. Set an environment,
+# export DPLPLAT_ENV=<platform environment name>
+# eg.
+$ export DPLPLAT_ENV=dplplat01
+
+# 2a. Authenticate against AKS, needed by infrastructure and Lagoon tasks
+$ task cluster:auth
+
+# 2b - if you want to use the Lagoon CLI)
+# The Lagoon CLI is authenticated via ssh-keys. DPLSH will mount your .ssh
+# folder from your homedir, but if your keys are passphrase protected, we need
+# to unlock them.
+$ eval $(ssh-agent); ssh-add
+# Then authorize the lagoon cli
+$ task lagoon:cli:config
+```
+
+

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -38,39 +38,7 @@ is put in to effect by running the appropiate `task` :
 
 ## Basic usage of dplsh and an environment configuration
 The remaining guides in this document assumes that you work from an instance
-of the [DPL shell](../../../dpl-platform/tools/dplsh), and that you have a
-properly authenticated azure CLI (`az`). This is require to bootstrap the access
-to the various credentials the tools requires to function.
-
-First `cd` to the `infrastructure`, then launch the shell.
-
-The shell will contact Azure to retrieve a storage account key Terraform needs to
-access its state, and export it and other require credentials via a number of
-environment variables. See `.dplsh.profile` for details.
-
-While inside the shell, use `DPLPLAT_ENV=<name> task` to run the pieces of
-automation you need or export `DPLPLAT_ENV` to simplify repeated executions.
-
-Running `task` without any arguments will yield a list of targets:
-
-```shell
-cd infrastructure
-dplsh
-# or if you do not have dplsh on path
-../tools/dplsh/dplsh.sh
-
-# From with the shell
-dplsh:~/host_mount$ DPLPLAT_ENV=dplplat01 task <target>
-
-# Or if you expect to run task multiple times
-dplsh:~/host_mount$ export DPLPLAT_ENV=dplplat01
-dplsh:~/host_mount$ task <target>
-```
-
-Any applied changes is persisted into the environments remote state-file. This
-means that you should be careful to coordinate when you commit changes to
-`.tf` files to git with when they are applied with your team. The recommended
-approach is to commit and merge any applied changes as quickly as possible.
+of the [DPL shell](../../../dpl-platform/tools/dplsh). See the [DPLSH Runbook](../documentation/runbooks/using-dplsh.md) for a basic introduction to how to use dplsh.
 
 # Installing a platform environment from scratch
 The following describes how to set up a whole new platform environment to host

--- a/tools/dplsh/README.md
+++ b/tools/dplsh/README.md
@@ -1,15 +1,38 @@
-# DPL Platform Operations Shell #
+# DPL Platform Operations Shell
 
 A small docker-based shell that eases the use of terraform and other ops tools.
 
 `dplsh` clones `${HOME}/.azure` into the shell which makes your local azure CLI state available from the shell. It also source `.dplsh.profile` if the file exists in the directory which allows you to implement project-specific tweaks.
 
 ## Prerequisites
+
 * Docker
 * [jq](https://stedolan.github.io/jq/download/)
 * Bash 4 or newer
 
+## Launching the shell
+
+The shell is launched via the `dplsh.sh` shell-script found in the same
+directory as this document. It is advisable to place a symlink to this file
+ on your path to make launching the shell easier
+
+```shell
+ln -s /path/to/checkout/tools/dplsh/dplsh.sh /usr/local/bin/dplsh
+```
+
+Should you need to launch the shell without having access to the shell-script
+it can be done by streaming it from the image like this:
+
+```shell
+# You need to do a one-time pull of the image:
+docker run docker.pkg.github.com/danskernesdigitalebibliotek/dpl-platform/dplsh:latest
+
+# Then launch the shell
+bash -c "$(docker run docker.pkg.github.com/danskernesdigitalebibliotek/dpl-platform/dplsh:latest bootstrap)"
+```
+
 ## Build and release
+
 The shell is based on a docker image. To produce a build and release it you
 simply build the docker image, and push it to the correct registry.
 
@@ -21,44 +44,33 @@ $ task build IMAGE_TAG=<some tag>
 $ task push
 ```
 
-## Launching the shell
-The shell is launched via the `dplsh.sh` shell-script found in the same
-directory as this document. It is advicable to place a symlink to this file
- on your path to make launching the shell easier
-```shell
-ln -s /path/to/checkout/tools/dplsh/dplsh.sh /usr/local/bin/dplsh
-```
+## Features
 
-Should you need to launch the shell without having access to the shell-script
-it can be done by streaming it from the image like this:
-```shell
-# You need to do a one-time pull of the image:
-docker run docker.pkg.github.com/danskernesdigitalebibliotek/dpl-platform/dplsh:latest
+### Shell profiles
 
-# Then launch the shell
-bash -c "$(docker run docker.pkg.github.com/danskernesdigitalebibliotek/dpl-platform/dplsh:latest bootstrap)"
-```
-
-## Shell profiles
 The following demonstrates a number of ways to use the profile feature of the
 shell. The shell will set its file-system root after the first profile it
 findes by traversing up towards the root of the host file-system. It then
 sources the file before starting the actual shell.
 
 ### Example 1
+
 ```shell
 $ touch /project/.dplsh.profile.my-profile
 $ cd /project/some/subpath
 $ dplsh -p my-profile
 ```
  dplsh will launch a container and do the following inside it
+
    * mount /project as /home/dplsh/host_mount
    * mount /project/.dplsh.profile.my-profile as  /home/dplsh/.dplsh.profile
    * cd to /home/dplsh/host_mount/some/subpath
    * source /home/dplsh/.dplsh.profile
+   *
 Notice, CWD while sourcing is the subdirectory the shell was launched for in.
 
 ### Example 2
+
 ```shell
 $ touch /project/.dplsh.profile
 $ cd /project/some/random
@@ -67,6 +79,7 @@ $ dplsh
 Same as example 1, but the shell will now default to .dplsh.profile
 
 ### Example 3:
+
 ```shell
 $ touch /project/subdir/.dplsh.profile
 $ cd /project/subdir


### PR DESCRIPTION
#### What does this PR do?
We wish to have a guide for a stable way of fetching and restoring
backups. This commit adds a runbook that describes this procedure.

As we introduce runbooks that describes one procedure, it becomes clear
that they has to reference other more general procedures. One such case
in this situation was how to run dplsh. So, I've also added a runbook
that describes the "how" of using dplsh. As a part of that effort I've
removed some sections from the infrastructure readme in favor of
referencing the runbook.

DDFDPDEL-116

#### Should this be tested by the reviewer and how?
Feel free to go through the process for a site.

#### Any specific requests for how the PR should be reviewed?
Be aware that I've done quite a bit of cleanup of the documentation and I still have some things coming down the pipeline later today. I might have a broke link or two in this PR or a reference to some documentation that does not exists. It's very likely that that documentation will land in a PR coming up in a moment.

#### What are the relevant tickets?
DDFDPDEL-176
