### PR TITLE
Document how to set environment variables

### DIFF
--- a/documentation/runbooks/add-site-to-platform.md
+++ b/documentation/runbooks/add-site-to-platform.md
@@ -81,18 +81,20 @@ $ task env_repos:provision
 # Refresh your Lagoon token.
 $ lagoon login
 
-# Then get it from ~/.lagoon.yml
-$ cat ~/.lagoon.yml
-$ export USER_TOKEN=<token>
-
-# Then export a github personal access-token with pull access
-$ export REGISTRY_PASSWORD=<github pat>
+# Then export a github personal access-token with pull access.
+# We could pass this to task directly like the rest of the variables but we
+# opt for the export to keep the execution of task a bit shorter.
+$ export VARIABLE_VALUE=<github pat>
 
 # Then get the project id by listing your projects
 $ lagoon list projects
 
 # Finally, add the credentials
-$ PROJECT_ID=<project id> task lagoon:add:registry-credentials
+$ VARIABLE_TYPE_ID=<project id> \
+  VARIABLE_TYPE=PROJECT \
+  VARIABLE_SCOPE=CONTAINER_REGISTRY \
+  VARIABLE_NAME=GITHUB_REGISTRY_CREDENTIALS \
+  task lagoon:set:environment-variable
 
 # If you get a "Invalid Auth Token" your token has probably expired, generated a
 # new with "lagoon login" and try again.

--- a/documentation/runbooks/deploy-a-release.md
+++ b/documentation/runbooks/deploy-a-release.md
@@ -21,6 +21,10 @@ site.
 # 1. Make any changes to the sites entry sites.yml you need.
 # 2. (optional) diff the deployment
 DIFF=1 SITE=<sitename> task site:sync
-# 3. Synchronize the site, triggering a deployment if the current state differs
+# 3a. Synchronize the site, triggering a deployment if the current state differs
 #    from the intended state in sites.yaml
+SITE=<sitename> task site:sync
+# 3b. If the state does not differ but you still want to trigger a deployment,
+#     specify FORCE=1
+FORCE=1 SITE=<sitename> task site:sync
 ```

--- a/documentation/runbooks/set-environment-variable.md
+++ b/documentation/runbooks/set-environment-variable.md
@@ -1,0 +1,55 @@
+# Add a new site to the platform
+
+## When to use
+
+When you wish to set an environment variable on a site. The variable can be
+available for either all sites in the project, or for a specific site in the
+project.
+
+The variables are safe for holding secrets.
+
+## Prerequisites
+
+* A running [dplsh](using-dplsh.md) with `DPLPLAT_ENV` set to the platform
+  environment name and ssh-agent running if your ssh-keys are passphrase
+  protected.
+* An user that has administrative privileges on the lagoon project in question.
+
+## Procedure
+
+```sh
+# From within a dplsh session authorized to use your ssh keys:
+
+# 1. Authenticate against the cluster and lagoon
+$ task cluster:auth
+$ task lagoon:cli:config
+
+# 2. Refresh your Lagoon token.
+$ lagoon login
+
+# 3. Then get the project id by listing your projects
+$ lagoon list projects
+
+# 4. Optionally, if you wish to set a variable for a single environment - eg a
+# pull-request site, list the environments in the project
+$ lagoon list environments -p <project name>
+
+# 5. Finally, set the variable
+# - Set the the type_id to the id of the project or environment depending on
+#   whether you want all or a single environment to access the variable
+# - Set scope to VARIABLE_TYPE or ENVIRONMENT depending on the choice above
+# - set
+$ VARIABLE_TYPE_ID=<project or environment id> \
+  VARIABLE_TYPE=<PROJECT or ENVIRONMENT> \
+  VARIABLE_SCOPE=RUNTIME \
+  VARIABLE_NAME=<your variable name> \
+  VARIABLE_VALUE=<your variable value> \
+  task lagoon:set:environment-variable
+
+# If you get a "Invalid Auth Token" your token has probably expired, generated a
+# new with "lagoon login" and try again.
+```
+
+The variable will be available the next time the site is deployed by Lagoon.
+Use [the deployment runbook](deploy-a-release.md) to trigger a deployment, use
+a forced deployment if you do not have a new release to deploy.

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -374,9 +374,9 @@ tasks:
       - sh: "[ ! -z ${HARBOR_ADMIN_PASS} ]"
         msg: "Could not extract the password for the Harbor admin from keyvault."
 
-    lagoon:add:registry-credentials:
+    lagoon:set:environment-variable:
       deps: [lagoon:cli:config]
-      desc: Adds image registry pull-credentials to a project
+      desc: Sets an environment variable on a lagoon site. This task automates the instructions from https://docs.lagoon.sh/lagoon/using-lagoon-advanced/environment-variables
 
       vars:
         # Collect the values we'll need for a graphql invocation.
@@ -386,6 +386,8 @@ tasks:
           sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".cluster_api_url.value | select (.!=null)"
         lagoon_domain_base:
           sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".lagoon_domain_base.value | select (.!=null)"
+        user_token:
+          sh: lagoon login > /dev/null && yq eval ".lagoons.{{.platform_env}}.token" - < ~/.lagoon.yml
 
         # Prepare the mutation.
         mutation: |
@@ -394,11 +396,11 @@ tasks:
             mutation addContainerRegistryEnv {
               addEnvVariable(
                 input:{
-                  type:PROJECT,
-                  typeId:{{.PROJECT_ID}},
-                  scope:CONTAINER_REGISTRY,
-                  name:\"GITHUB_REGISTRY_CREDENTIALS\",
-                  value:\"{{.REGISTRY_PASSWORD}}\"
+                  type:{{.VARIABLE_TYPE}},
+                  typeId:{{.VARIABLE_TYPE_ID}},
+                  scope:{{.VARIABLE_SCOPE}},
+                  name:\"{{.VARIABLE_NAME}}\",
+                  value:\"{{.VARIABLE_VALUE}}\"
                 }
               ) {
                 id
@@ -412,7 +414,7 @@ tasks:
         - |
           curl \
             -H 'Content-Type: application/json' \
-            -H "Authorization: Bearer {{.USER_TOKEN}}" \
+            -H "Authorization: Bearer {{.user_token}}" \
             -d '{{.mutation | replace "\n" ""}}' \
             https://{{.lagoon_hostname_api}}/graphql
 
@@ -423,12 +425,16 @@ tasks:
         msg: "Could not determine the hostname for the Kubernetes API"
       - sh: "[ ! -z {{.lagoon_domain_base}} ]"
         msg: "Could not determine the Lagoon base domain"
-      - sh: "[ ! -z {{.USER_TOKEN}} ]"
-        msg: "Missing USER_TOKEN"
-      - sh: "[ ! -z {{.REGISTRY_PASSWORD}} ]"
-        msg: "Missing REGISTRY_PASSWORD"
-      - sh: "[ ! -z {{.PROJECT_ID}} ]"
-        msg: "Missing PROJECT_ID"
+      - sh: "[ ! -z {{.VARIABLE_VALUE}} ]"
+        msg: "Missing VARIABLE_VALUE"
+      - sh: "[ ! -z {{.VARIABLE_TYPE_ID}} ]"
+        msg: "Missing VARIABLE_TYPE_ID"
+      - sh: "[ ! -z {{.VARIABLE_NAME}} ]"
+        msg: "Missing VARIABLE_NAME"
+      - sh: "[ ! -z {{.VARIABLE_SCOPE}} ]"
+        msg: "Missing VARIABLE_SCOPE"
+      - sh: "[ ! -z {{.VARIABLE_TYPE}} ]"
+        msg: "Missing VARIABLE_TYPE"
 
     lagoon:add:cluster:
       deps: [cluster:auth]


### PR DESCRIPTION
#### What does this PR do?
We already had some documentation on how to set an variable on a lagoon
project in order for the build-process to access private image-registries

This PR builds on that work and generalises the task so that it can
be used to set any environment variable. The task automates the steps
to set an environment variable as documented in https://docs.lagoon.sh/lagoon/using-lagoon-advanced/environment-variables

This commit also simplifies the process a bit by now picking up an users
lagoon bearer token directly from the lagoon login context instead of
having the user perform that step manually.

Last but not least, I add a missing step to the site deploy runbook.

#### Should this be tested by the reviewer and how?
You should be able to go through the steps and then verify that an environment-
variable has landed on the site. I've gone through those
steps for the tbd-bib-rb site so another approach sould just be to
verify that site.

