### PR TITLE
Have lagoon construct rootless workloads

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -14,6 +14,7 @@ lagoon-build-deploy:
   taskSSHHost: "$SSH_LOADBALANCER_IP"
   taskSSHPort: "22"
   taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
+  lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
 dbaas-operator:
   enabled: true
 


### PR DESCRIPTION
#### What does this PR do?
Without this flag the build pod would run workloads (nginx, php etc)
as root.

#### Should this be tested by the reviewer and how?
The change has already been deployed - so verify that new builds now does not run as root.
