### PR TITLE
Import translations when deploying library sites

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -30,6 +30,16 @@ tasks:
             fi
         service: cli
     - run:
+        # We need this because if we create the directory before volume mount
+        # it will be gone.
+        name: Create module upload directory in public files
+        command: |
+            if [[ ! -d "web/sites/default/files/modules_local" ]]; then
+                echo "Creating directory for module uploads"
+                mkdir web/sites/default/files/modules_local
+            fi
+        service: cli
+    - run:
         name: Import translations
         command: |
             drush locale-check


### PR DESCRIPTION
#### What does this PR do?
Adds import cmds when deploying library sites
Symlink creation for library sites also was added, because it was forgotten.

#### Should this be tested by the reviewer and how?
Deploy a library site and the translation file should be imported. 

#### Any specific requests for how the PR should be reviewed?
Go through the two commits

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDPDEL-195