### PR TITLE
Increase storage provisioned for mariadb for increased performance

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -10,6 +10,12 @@ module "environment" {
   node_pool_system_count          = 1
   node_pool_app_default_count_min = 2
   node_pool_app_default_count_max = 5
+  # We've increased this quite a bit to test performance. The ideal starting-
+  # point seems to be in the range 102400 - 204800 to get enough IOPS to
+  # maintain performance during a Drupal site-install.
+  # When copying this value, consider leaving it out and falling back to the
+  # default of 102400.
+  sql_storage_mb = 409600
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment

--- a/infrastructure/terraform/modules/dpl-platform-environment/db.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/db.tf
@@ -43,14 +43,11 @@ resource "azurerm_mariadb_server" "sql" {
   # for all tiers: https://docs.microsoft.com/en-us/azure/mysql/concepts-data-access-security-private-link
   public_network_access_enabled = true
 
-  # TODO, we need to verifiy whether this can be toggled on. We'll know it when
-  # the first version of Lagoon is up and running.
+  # Lagoon does not yet support TLS.
   ssl_enforcement_enabled = false
 }
 
 # Allow any inbound connections
-# TODO: verifiy that we actually need this during the initial installation of
-# lagoon. It seems that the next rule should at the very least work.
 resource "azurerm_mariadb_firewall_rule" "anyany" {
   name                = "any-any"
   resource_group_name = azurerm_resource_group.rg.name

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -86,7 +86,7 @@ variable "sql_version" {
 }
 
 variable "sql_storage_mb" {
-  description = "Amount of storage to request for the MariaDB services"
+  description = "Amount of storage to request for the MariaDB services. Be aware that the number of IOPS you get scales with the storage size. 100GB will give you 300IOPS, every additional GB gives you 3 IOPS"
   type        = number
-  default     = 5120
+  default     = 102400
 }


### PR DESCRIPTION
#### What does this PR do?
The MariaDB server provisioned to support Lagoon is set up with a
configurable amount of storage. The amount of IOPS the server can perform
against the storage scales linearly with the amount of provisioned
storage.

Before this commit the dpl-platform-environment Terraform module would
default to provision 5GB of storage, which gave us 100IOPS.

This is not enough to support a Drupal site install where the Redis
cache is disabled and the database is used as a fallback cache store.

This commit increases the default to 102400, and updates the current
value for dplplat01 to 409600 which is the result of some experimentation
that showed that 102400 is probably enough going foreward

DDFDPDEL-196

#### Should this be tested by the reviewer and how?
Has already been provisioned, so just read through the modifications
and see if you agree.

#### What are the relevant tickets?
Was done during the tuning of harbor: DDFDPDEL-196
