### PR TITLE
Correct run-a-lagoon-task documentation

### DIFF
--- a/documentation/runbooks/run-a-lagoon-task.md
+++ b/documentation/runbooks/run-a-lagoon-task.md
@@ -12,7 +12,7 @@ You need access to the [Lagoon UI][url-lagoon-ui]
 
 * Login to the Lagoon UI.
 * Navigate to the project you want to access.
-* Choose the environment you want to login to.
+* Choose the environment you want to interact with.
 * Click the "Tasks" tab.
 
 [url-lagoon-ui]: https://github.com/danskernesdigitalebibliotek/dpl-platform/blob/main/documentation/platform-environments.md#urls


### PR DESCRIPTION
#### What does this PR do?
The originial docuemntation was written about how to run login task.
This commit corrects the procudre step to be more generic

