### PR TITLE
Adding ui pasword helper task

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -593,6 +593,14 @@ tasks:
       - sh: "[ ! -z {{.SITE}} ]"
         msg: "Env variable SITE is not set or empty."
 
+    ui-password:
+      desc: Get the password to access a given user interface
+      cmds:
+      - task/scripts/ui-password.sh
+      preconditions:
+      - sh: "[ ! -z {{.UI_NAME}} ]"
+        msg: "Env variable UI_NAME is not set or empty."
+
     _req_env:
       preconditions:
       - sh: "[ ! -z {{.DPLPLAT_ENV}} ]"

--- a/infrastructure/task/scripts/ui-password.sh
+++ b/infrastructure/task/scripts/ui-password.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Get varoius UI passwords.
+# Meant as a helper script for manually logging into user interfaces.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=./util.source.sh
+source "${SCRIPT_DIR}/util.source.sh"
+
+# These variables is taken from the environment.
+verifyVariable "UI_NAME"
+
+# Get password if possible.
+case $UI_NAME in
+
+  grafana)
+    NAMESPACE="grafana"
+    SECRET="grafana"
+    JSON_PATH="{.data.admin-password}"
+    ;;
+  harbor)
+    NAMESPACE="harbor"
+    SECRET="harbor-harbor-core"
+    JSON_PATH="{.data.HARBOR_ADMIN_PASSWORD}"
+    ;;
+  keycloak)
+    NAMESPACE="lagoon-core"
+    SECRET="lagoon-core-keycloak"
+    JSON_PATH="{.data.KEYCLOAK_ADMIN_PASSWORD}"
+    ;;
+  lagoon)
+    NAMESPACE="lagoon-core"
+    SECRET="lagoon-core-keycloak"
+    JSON_PATH="{.data.KEYCLOAK_LAGOON_ADMIN_PASSWORD}"
+    ;;
+  *)
+    echo "The UI name ${UI_NAME} is unknown."
+    exit 1;
+    ;;
+esac
+
+# Output password.
+kubectl get secrets -n $NAMESPACE $SECRET -o jsonpath=$JSON_PATH | base64 -d; echo


### PR DESCRIPTION
#### What does this PR do?

Since the operator already has access to kubectl and can fetch the secrets
we might as well use a helper task to retrieve the passwords
for the various UI's in the platform.



#### Should this be tested by the reviewer and how?
Look at it.
Try to run `UI_NAME=grafana task ui-password`
try to change the UI_NAME to other values.

