### PR TITLE
Update dpl build workflow and switch to multiarch

### DIFF
--- a/.github/workflows/dplsh-build-release.yaml
+++ b/.github/workflows/dplsh-build-release.yaml
@@ -6,70 +6,91 @@
 on:
   pull_request:
     paths:
-    - 'tools/dplsh/**'
-    - '.github/workflows/dplsh-build-release.yaml'
+      - "tools/dplsh/**"
+      - ".github/workflows/dplsh-build-release.yaml"
   push:
     branches:
-    - master
-    # Limit pushes on master to only build if these files has changed.
+      - main
+    # Limit pushes on main to only build if these files has changed.
     paths:
-    - 'tools/dplsh/**'
-    - '.github/workflows/dplsh-build-release.yaml'
+      - "tools/dplsh/**"
+      - ".github/workflows/dplsh-build-release.yaml"
     tags:
-    - 'dplsh-*'
+      - "dplsh-*"
 
 name: Build, test and publish DPL Shell image
 jobs:
   dplsh_build:
+    name: Build, test and publish DPL Shell image
     runs-on: ubuntu-latest
+    permissions:
+      # Allow push to ghcr
+      packages: write
     # Set some environment vars about the image and container registry.
     env:
       # Registry to push the image to.
       repo: ghcr.io
       # Complete registry url for image. (omitting image name).
       image-url: ghcr.io/danskernesdigitalebibliotek/dpl-platform/dplsh
-      # Name of the container image to build and push.
-      image: dplsh
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.3.4
-    - name: Install Task
-      uses: Arduino/actions/setup-taskfile@master
-    # Generate a sane tag based on current git ref (branch, tag, etc).
-    - uses: rlespinasse/github-slug-action@v3.x
-    - name: Build ${{env.image}} container image
-      env:
-        IMAGE_URL: working-image
-        IMAGE_TAG: 0.0.0
-      run: task build
-      working-directory: tools/dplsh
-    - name: Test ${{env.image}} container image
-      env:
-        IMAGE_URL: working-image
-        IMAGE_TAG: 0.0.0
-      run: task test
-      working-directory: tools/dplsh
-    # Publish to container registry if this was a push event (not a PR).
-    - name: Publish image to registry
-      if: github.event_name == 'push'
-      run: |
-        IMAGE_VERSION=
-        # If this is a push of a tag, do a docker tag and push
-        if [[ "${{github.ref}}" == refs/tags/* ]]; then
-          # If we build a tag, push that image to docker tag.
-          IMAGE_VERSION=$(echo ${GITHUB_REF_SLUG} | sed -e 's/^${{env.image}}-//')
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - name: Install Task
+        uses: arduino/setup-task@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Setup QEMU and buildx so that we can build multiarch images.
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # Pickup metadata for tags and labels.
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{env.image-url}}
+          labels: |
+            org.opencontainers.image.title=DPL Shell
+            org.opencontainers.image.description=Danish Public Libraries infrastructure Shell
 
-          # Push the service-image to the github registry.
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ${{env.repo}} -u username-is-ignored --password-stdin
-          # Tag latest and release version
-          docker tag working-image:0.0.0 ${{env.image-url}}:$IMAGE_VERSION
-          docker tag working-image:0.0.0 ${{env.image-url}}:latest
-          # And push to github registry
-          docker push ${{env.image-url}}:$IMAGE_VERSION
-          docker push ${{env.image-url}}:latest
-        fi
-    - name: Create release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Do a first build and export it to the docker cache. This allows us to
+      # run som tests on the image, while still avoiding to have to rebuild the
+      # image when we do the final build.
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: tools/dplsh
+          load: true
+          tags: working-image:0.0.0
+
+      - name: Test the dplsh container image
+        env:
+          IMAGE_URL: working-image
+          IMAGE_TAG: 0.0.0
+        run: task test
+        working-directory: tools/dplsh
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: tools/dplsh
+          platforms: linux/amd64,linux/arm64
+          # push: github.event_name == 'push'
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+      # Create a github release if this was a tag.
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -5,17 +5,17 @@ ARG DPLSH_BUILD_VERSION=latest
 FROM alpine/helm:3.7.2 as helm
 
 # https://hub.docker.com/r/hashicorp/terraform/tags?page=1&ordering=last_updated
-FROM hashicorp/terraform:1.1.1 as terraform
+FROM hashicorp/terraform:1.2.6 as terraform
 
 # We use the official azure cli as a base-image. It is itself based on alpine
 # and is quite minimal.
 # https://mcr.microsoft.com/v2/azure-cli/tags/list
-FROM mcr.microsoft.com/azure-cli:2.31.0
+FROM mcr.microsoft.com/azure-cli:2.39.0
 
-ARG TASK_VERSION=v3.4.2
+ARG TASK_VERSION=v3.14.1
 ARG STERN_RELEASE=1.11.0
-ARG LAGOON_CLI_RELEASE=v0.12.0
-ARG KREW_VERSION=v0.4.2
+ARG LAGOON_CLI_RELEASE=v0.13.0
+ARG KREW_VERSION=v0.4.3
 # This version can be bumped as we upgrade the cluster minor version.
 ARG KUBECTL_VERSION=v1.20.9
 


### PR DESCRIPTION
#### What does this PR do?
Updates the github action workflow that builds, tests and releases dplsh.

This update
- Reformats the file
- Fixes a bug where we triggered on the nonexistent "master" branch (should be main)
- Simplified the workflow by using a docker meta action for generating labels and tags
- Switched to buildx to do multiarch builds


#### Should this be tested by the reviewer and how?
The action tests itself, I've temporarily allowed it to always push so the runs made by this PR shuold create a full reelase.

