### PR TITLE
Upgrade Lagoon to latest version - DDFDPDEL-206

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable first-line-h1 -->
+<!-- markdownlint-disable no-multiple-blanks -->
 #### What does this PR do?
 
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,3 +3,5 @@ globs:
 
 ignores:
   - '.git'
+  - './**/.terraform'
+  - 'node_modules'

--- a/documentation/runbooks/upgrading-lagoon.md
+++ b/documentation/runbooks/upgrading-lagoon.md
@@ -1,0 +1,45 @@
+# Upgrading Lagoon
+
+## When to use
+
+When there is a need to upgrade Lagoon to a new patch or minor version.
+
+## References
+
+* Official [Updating](https://docs.lagoon.sh/installing-lagoon/update-lagoon/) documentation.
+* Lagoon [Releases](https://github.com/uselagoon/lagoon/releases)
+
+## Prerequisites
+
+* A running [dplsh](using-dplsh.md) with `DPLPLAT_ENV` set to the platform
+  environment name.
+* Knowledge about the version of Lagoon you want to upgrade to.
+  * You can extract version (= chart version) and appVersion (= lagoon release
+    version) for the lagoon-remote / lagoon-core charts via the following commands
+    (replace lagoon-core for lagoon-remote if necessary).
+
+```shell
+curl -s https://uselagoon.github.io/lagoon-charts/index.yaml \
+  | yq '.entries.lagoon-core[] | [.name, .appVersion, .version, .created] | @tsv'
+```
+
+* Knowledge of any breaking changes or necessary actions that may affect the
+  platform when upgrading. See chart release notes for *all* intermediate chart
+  releases.
+
+## Procedure
+
+1. Upgrade Lagoon core
+    1. Bump the chart version in `infrastructure/environments/<env>/lagoon/lagoon-versions.env`
+    2. Perform a helm diff
+       * `DIFF=1 task lagoon:provision:core`
+    3. Perform the actual upgrade
+       * `task lagoon:provision:core`
+    4. Run database migrations
+      * `task lagoon:provision:core-db-migration`
+2. Upgrade Lagoon remote
+    1. Bump the chart version in `infrastructure/environments/dplplat01/lagoon/lagoon-versions.env`
+    2. Perform a helm diff
+       * `DIFF=1 task lagoon:provision:remote`
+    3. Perform the actual upgrade
+       * `task lagoon:provision:remote`

--- a/documentation/runbooks/upgrading-lagoon.md
+++ b/documentation/runbooks/upgrading-lagoon.md
@@ -30,16 +30,20 @@ curl -s https://uselagoon.github.io/lagoon-charts/index.yaml \
 ## Procedure
 
 1. Upgrade Lagoon core
-    1. Bump the chart version in `infrastructure/environments/<env>/lagoon/lagoon-versions.env`
+    1. Bump the chart version in
+       `infrastructure/environments/<env>/lagoon/lagoon-versions.env`
+       and set `BUILD_DEPLOY_DIND_IMAGE` to the new version of Lagoon
     2. Perform a helm diff
-       * `DIFF=1 task lagoon:provision:core`
+        * `DIFF=1 task lagoon:provision:core`
     3. Perform the actual upgrade
-       * `task lagoon:provision:core`
+        * `task lagoon:provision:core`
     4. Run database migrations
-      * `task lagoon:provision:core-db-migration`
+        * `task lagoon:provision:core-db-migration`
 2. Upgrade Lagoon remote
-    1. Bump the chart version in `infrastructure/environments/dplplat01/lagoon/lagoon-versions.env`
+    1. Bump the chart version in
+      `infrastructure/environments/dplplat01/lagoon/lagoon-versions.env`
     2. Perform a helm diff
-       * `DIFF=1 task lagoon:provision:remote`
+        * `DIFF=1 task lagoon:provision:remote`
     3. Perform the actual upgrade
-       * `task lagoon:provision:remote`
+        * `task lagoon:provision:remote`
+    4. Take note in the output from Helm of any CRD updates that *may* be required

--- a/infrastructure/.dplsh.profile
+++ b/infrastructure/.dplsh.profile
@@ -7,5 +7,7 @@ export DNSIMPLE_ACCOUNT="61014"
 echo
 echo "Now run"
 echo "   export DPLPLAT_ENV=<environment>"
-echo "to set your platform environment, then run "task" to continue your work..."
+echo "to set your platform environment, then run "task" to continue your work."
+echo "consult https://github.com/danskernesdigitalebibliotek/dpl-platform/blob/main/documentation/platform-environments.md"
+echo "for a list of environments"
 echo

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -76,8 +76,8 @@ task infra:provision
 
 # Create DNS record
 Create an A record in the administration area of your DNS provider.
-Take the terraform output: "ingress_ip" of the former command and create an entry like:
-"*.[DOMAN_NAME].[TLD]": "[ingress_ip]"
+Take the terraform output: "ingress_ip" of the former command and create an entry
+like: "*.[DOMAN_NAME].[TLD]": "[ingress_ip]"
 
 # Provision the support software that the Platform relies on
 task support:provision

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -90,7 +90,7 @@ tasks:
                 )
               --query value -o tsv
       cmds:
-        - cmd: cd {{.dir_env_repos}} && terraform apply
+        - cmd: terraform -chdir {{.dir_env_repos}} apply
 
     cluster:auth:
         deps: [_req_env]
@@ -98,9 +98,9 @@ tasks:
         dir: "{{.dir_infra}}"
         vars:
           CLUSTER_NAME:
-            sh: terraform output -json | jq --raw-output ".cluster_name.value | select (.!=null)"
+            sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".cluster_name.value | select (.!=null)"
           RESOURCEGROUP_NAME:
-            sh: terraform output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
+            sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
         status:
           - "[ $(kubectl config view --output jsonpath='{.current-context}') == '{{.CLUSTER_NAME}}' ] || exit 1"
         cmds:
@@ -126,7 +126,7 @@ tasks:
         INGRESS_IP:
           sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".ingress_ip.value | select (.!=null)"
         RESOURCE_GROUP:
-          sh: terraform  -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
+          sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
       cmds:
         - task/scripts/provision-ingress-nginx.sh
 
@@ -264,6 +264,12 @@ tasks:
         msg: "Could not extract the password for the keycloak admin from keyvault."
       - sh: "[ ! -z ${HARBOR_ADMIN_PASS} ]"
         msg: "Could not extract the password for the harbor admin from keyvault."
+
+    lagoon:provision:core-db-migration:
+      deps: [cluster:auth]
+      desc: Run database migrations after an upgrade
+      cmds:
+        - kubectl --namespace lagoon-core exec -it lagoon-core-api-db-0 -- sh -c /rerun_initdb.sh
 
     lagoon:cli:config:
       deps: [cluster:auth]
@@ -533,7 +539,7 @@ tasks:
         STORAGE_ACCOUNT_KEY:
           sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".storage_primary_access_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
         RESOURCE_GROUP:
-          sh: terraform  -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
+          sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
       cmds:
         - task/scripts/provision-bulk-storage.sh
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -345,10 +345,12 @@ tasks:
           sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".sql_password_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
         CHART_VERSION_LAGOON_REMOTE:
           sh: source "{{.dir_lagoon}}/lagoon-versions.env" && echo $VERSION_LAGOON_REMOTE
+        BUILD_DEPLOY_DIND_IMAGE:
+          sh: source "{{.dir_lagoon}}/lagoon-versions.env" && echo $BUILD_DEPLOY_DIND_IMAGE
       cmds:
         # Render the variables we've collected into a values file we can install.
         - |
-          envsubst '$SSH_LOADBALANCER_IP $RABBITMQ_PASS $HARBOR_ADMIN_PASS $SQL_HOSTNAME $SQL_SERVERNAME $SQL_USER $SQL_PASSWORD' \
+          envsubst '$SSH_LOADBALANCER_IP $RABBITMQ_PASS $HARBOR_ADMIN_PASS $SQL_HOSTNAME $SQL_SERVERNAME $SQL_USER $SQL_PASSWORD $BUILD_DEPLOY_DIND_IMAGE' \
           < "{{.dir_lagoon}}/lagoon-remote-values.template.yaml" \
           > "{{.dir_lagoon}}/lagoon-remote-values.yaml"
         # Setup the namespace manually to control eg. labels on the namespace.
@@ -611,4 +613,3 @@ tasks:
         msg: "Could not find directory {{.dir_infra}}"
       - sh: "[ -d {{.dir_configuration}} ]"
         msg: "Could not find directory {{.dir_configuration}}"
-

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -15,6 +15,7 @@ lagoon-build-deploy:
   taskSSHPort: "22"
   taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
   lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
+  overrideBuildDeployImage: "$BUILD_DEPLOY_DIND_IMAGE"
 dbaas-operator:
   enabled: true
 

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
@@ -1,8 +1,8 @@
 # Get Lagoon versions from the Chart.yml - inspect appVersion to determine which
 # version of lagoon is installed
 
-# Current appVersion for remote and core is v2.2.4
+# Current appVersion for remote and core is v2.9.2
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-core/Chart.yaml#L20
-VERSION_LAGOON_CORE=0.61.0
+VERSION_LAGOON_CORE=1.5.0
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/Chart.yaml#L21
-VERSION_LAGOON_REMOTE=0.42.0
+VERSION_LAGOON_REMOTE=0.58.1

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
@@ -6,3 +6,7 @@
 VERSION_LAGOON_CORE=1.5.0
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/Chart.yaml#L21
 VERSION_LAGOON_REMOTE=0.58.1
+
+# This should match the currently installed version of Lagoon Remote.
+# See https://github.com/uselagoon/lagoon-charts/releases/tag/lagoon-core-1.2.0
+BUILD_DEPLOY_DIND_IMAGE=v2.9.2

--- a/tools/dplsh/README.md
+++ b/tools/dplsh/README.md
@@ -72,7 +72,6 @@ dplsh -p my-profile
 * cd to /home/dplsh/host_mount/some/subpath
 * source /home/dplsh/.dplsh.profile
 
-*
 Notice, CWD while sourcing is the subdirectory the shell was launched for in.
 
 ### Example 2


### PR DESCRIPTION
#### What does this PR do?

We have now upgraded the `dplplat01` env to the latest release of Lagoon ([v2.9.2](https://github.com/uselagoon/lagoon/releases/tag/v2.9.2)).

This bumps the env variables that we keep in the repo to align with that version.

Furthermore, we add the `overrideBuildDeployImage` chart variable to or env vars in order to pin the Build & Deploy image to the current Lagoon Remote version. Lagoon will default to `:latest` otherwise. This was introduced in [Lagoon Core chart version 1.2.0](https://github.com/uselagoon/lagoon-charts/releases/tag/lagoon-core-1.2.0).

This also adds documentation for the upgrade procedure.

#### Should this be tested by the reviewer and how?

Log in to https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms to confirm the current version.

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDFDPDEL-206
