### PR TITLE
Fix build-deploy image in Lagoon

### DIFF
--- a/documentation/runbooks/upgrading-lagoon.md
+++ b/documentation/runbooks/upgrading-lagoon.md
@@ -30,9 +30,8 @@ curl -s https://uselagoon.github.io/lagoon-charts/index.yaml \
 ## Procedure
 
 1. Upgrade Lagoon core
-    1. Bump the chart version in
+    1. Bump the chart version `VERSION_LAGOON_CORE` in
        `infrastructure/environments/<env>/lagoon/lagoon-versions.env`
-       and set `BUILD_DEPLOY_DIND_IMAGE` to the new version of Lagoon
     2. Perform a helm diff
         * `DIFF=1 task lagoon:provision:core`
     3. Perform the actual upgrade
@@ -40,10 +39,11 @@ curl -s https://uselagoon.github.io/lagoon-charts/index.yaml \
     4. Run database migrations
         * `task lagoon:provision:core-db-migration`
 2. Upgrade Lagoon remote
-    1. Bump the chart version in
+    1. Bump the chart version `VERSION_LAGOON_REMOTE` in
       `infrastructure/environments/dplplat01/lagoon/lagoon-versions.env`
-    2. Perform a helm diff
+    2. Set `BUILD_DEPLOY_DIND_IMAGE_VER` to the new version of Lagoon
+    3. Perform a helm diff
         * `DIFF=1 task lagoon:provision:remote`
-    3. Perform the actual upgrade
+    4. Perform the actual upgrade
         * `task lagoon:provision:remote`
-    4. Take note in the output from Helm of any CRD updates that *may* be required
+    5. Take note in the output from Helm of any CRD updates that *may* be required

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -351,12 +351,12 @@ tasks:
           sh: az keyvault secret show --subscription "{{.AZURE_SUBSCRIPTION_ID}}" --name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".sql_password_key_name.value | select (.!=null)") --vault-name $(terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)") --query value -o tsv
         CHART_VERSION_LAGOON_REMOTE:
           sh: source "{{.dir_lagoon}}/lagoon-versions.env" && echo $VERSION_LAGOON_REMOTE
-        BUILD_DEPLOY_DIND_IMAGE:
-          sh: source "{{.dir_lagoon}}/lagoon-versions.env" && echo $BUILD_DEPLOY_DIND_IMAGE
+        BUILD_DEPLOY_DIND_IMAGE_VER:
+          sh: source "{{.dir_lagoon}}/lagoon-versions.env" && echo $BUILD_DEPLOY_DIND_IMAGE_VER
       cmds:
         # Render the variables we've collected into a values file we can install.
         - |
-          envsubst '$SSH_LOADBALANCER_IP $RABBITMQ_PASS $HARBOR_ADMIN_PASS $SQL_HOSTNAME $SQL_SERVERNAME $SQL_USER $SQL_PASSWORD $BUILD_DEPLOY_DIND_IMAGE' \
+          envsubst '$SSH_LOADBALANCER_IP $RABBITMQ_PASS $HARBOR_ADMIN_PASS $SQL_HOSTNAME $SQL_SERVERNAME $SQL_USER $SQL_PASSWORD $BUILD_DEPLOY_DIND_IMAGE_VER' \
           < "{{.dir_lagoon}}/lagoon-remote-values.template.yaml" \
           > "{{.dir_lagoon}}/lagoon-remote-values.yaml"
         # Setup the namespace manually to control eg. labels on the namespace.

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -15,7 +15,7 @@ lagoon-build-deploy:
   taskSSHPort: "22"
   taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
   lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
-  overrideBuildDeployImage: "$BUILD_DEPLOY_DIND_IMAGE"
+  overrideBuildDeployImage: "uselagoon/kubectl-build-deploy-dind:$BUILD_DEPLOY_DIND_IMAGE_VER"
 dbaas-operator:
   enabled: true
 

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
@@ -7,6 +7,7 @@ VERSION_LAGOON_CORE=1.5.0
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/Chart.yaml#L21
 VERSION_LAGOON_REMOTE=0.58.1
 
-# This should match the currently installed version of Lagoon Remote.
+# This should match the currently installed version of Lagoon Remote. It
+# actually maps to an image tag here: https://hub.docker.com/r/uselagoon/kubectl-build-deploy-dind/tags
 # See https://github.com/uselagoon/lagoon-charts/releases/tag/lagoon-core-1.2.0
-BUILD_DEPLOY_DIND_IMAGE=v2.9.2
+BUILD_DEPLOY_DIND_IMAGE_VER=v2.9.2


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This fixes a bug with how the `overrideBuildDeployImage` chart var was defined, causing the build-deploy image to break during deploys.
