### PR TITLE
Fix cluster:auth task

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -95,7 +95,6 @@ tasks:
     cluster:auth:
         deps: [_req_env]
         desc: "Authenticate against AKS and setup a functional kubecontext."
-        dir: "{{.dir_infra}}"
         vars:
           CLUSTER_NAME:
             sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".cluster_name.value | select (.!=null)"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Since we are using `terraform -chdir=` to invoke terraform from an env subdir, we do not also need to ask Task to chdir for us first.

This fixes that behaviour.
