### PR TITLE
Bump limit for dev environments

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -506,11 +506,13 @@ tasks:
         # - We deploy the main and develop branch
         # - We configure the main branch to be the production environment,
         #   This primarily means that develop will auto-idle
+        # - We bump the max allowed dev environments (default is 5)
         - |
             lagoon add project \
             --gitUrl {{.GIT_URL}} \
             --openshift 1 \
             --productionEnvironment main \
+            --developmentEnvironmentsLimit 25 \
             --branches "^(main|develop)$" \
             --project {{.PROJECT_NAME}}
         - task: lagoon:project:deploykey


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This will bump the environment limit for all new projects when we create them, from 5 to 25.

This is probably a more sane default than the current upstream one.