### PR TITLE
Upgrade Lagoon and AKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .history
+# go-task uses these directories for tracking file modifications
+.task

--- a/documentation/runbooks/upgrading-aks.md
+++ b/documentation/runbooks/upgrading-aks.md
@@ -62,11 +62,34 @@ task infra:provision
 
 ### Upgrade the cluster
 
-1. Then update the `kubernetes_version` reference in `infrastructure/environments/<environment>/infrastructure/main.tf`
+Upgrade the control-plane:
+
+1. Update the `control_plane_version` reference in `infrastructure/environments/<environment>/infrastructure/main.tf`
   and run `task infra:provision` to apply. You can skip patch-versions, but you
   can only do [one minor-version at the time](https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster?tabs=azure-cli#check-for-available-aks-cluster-upgrades)
 
-2. Then monitor the upgrade as it progresses. Eg via
+2. Monitor the upgrade as it progresses. A control-plane upgrade is usually performed
+   in under 5 minutes.
+
+Monitor via eg.
+
+```shell
+watch -n 5 kubectl version
+```
+
+Then upgrade the system, admin and application node-pools in that order one by
+one.
+
+1. Update the `pool_[name]_version` reference in
+   `infrastructure/environments/<environment>/infrastructure/main.tf`.
+   The same rules applies for the version as with `control_plane_version`.
+
+2. Monitor the upgrade as it progresses. Expect the provisioning of and workload
+   scheduling to a single node to take about 5-10 minutes. In particular be aware
+   that the admin node-pool where harbor runs has a tendency to take a long time
+   as the harbor pvcs are slow to migrate to the new node.
+
+Monitor via eg.
 
 ```shell
 watch -n 5 kubectl get nodes

--- a/infrastructure/environments/dplplat01/configuration/harbor/harbor-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/harbor/harbor-values.template.yaml
@@ -26,6 +26,23 @@ registry:
 
 # Use Azure blob storage for persistence
 persistence:
+  persistentVolumeClaim:
+    jobservice:
+      scanDataExports:
+        # The actual size of the disk Azure will give us if we ask for a 1Gi
+        size: 4Gi
+      jobLog:
+        # The actual size of the disk Azure will give us if we ask for a 1Gi
+        size: 4Gi
+  # It was not possible to change the values below after the initial provisioning
+  # as they are stateful sets, but the PVCs has been modified manually to
+  # match these values.
+  # database:
+  #   # The actual size of the disk Azure will give us if we ask for a 1Gi
+  #   size: 4Gi
+  # redis:
+  #   # The actual size of the disk Azure will give us if we ask for a 1Gi
+  #   size: 4Gi
   imageChartStorage:
     type: "azure"
     azure:

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -16,10 +16,10 @@ module "environment" {
   # When copying this value, consider leaving it out and falling back to the
   # default of 102400.
   sql_storage_mb          = 409600
-  control_plane_version   = "1.23"
-  pool_admin_version      = "1.23"
-  pool_appdefault_version = "1.23"
-  pool_system_version     = "1.23"
+  control_plane_version   = "1.24"
+  pool_system_version     = "1.24"
+  pool_admin_version      = "1.24"
+  pool_appdefault_version = "1.24"
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -15,8 +15,11 @@ module "environment" {
   # maintain performance during a Drupal site-install.
   # When copying this value, consider leaving it out and falling back to the
   # default of 102400.
-  sql_storage_mb     = 409600
-  kubernetes_version = "1.22.15"
+  sql_storage_mb          = 409600
+  control_plane_version   = "1.23"
+  pool_admin_version      = "1.23"
+  pool_appdefault_version = "1.23"
+  pool_system_version     = "1.23"
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment
@@ -93,8 +96,8 @@ output "keyvault_name" {
   value = module.environment.keyvault_name
 }
 
-output "kubernetes_version" {
-  value = module.environment.kubernetes_version
+output "control_plane_version" {
+  value = module.environment.control_plane_version
 }
 
 output "keycloak_admin_pass_key_name" {

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-versions.env
@@ -1,11 +1,11 @@
 # Get Lagoon versions from the Chart.yml - inspect appVersion to determine which
 # version of lagoon is installed
 
-# Current appVersion for remote and core is v2.10.0
+# Current appVersion for remote and core is v2.11.0
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-core/Chart.yaml#L20
-VERSION_LAGOON_CORE=1.12.1
+VERSION_LAGOON_CORE=1.16.0
 # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-remote/Chart.yaml#L21
-VERSION_LAGOON_REMOTE=0.64.0
+VERSION_LAGOON_REMOTE=0.69.2
 
 # This should match the currently installed version of Lagoon Remote. It
 # actually maps to an image tag here: https://hub.docker.com/r/uselagoon/kubectl-build-deploy-dind/tags
@@ -13,4 +13,8 @@ VERSION_LAGOON_REMOTE=0.64.0
 #
 # Note for Lagoon v2.10.0 - it did not have a matching build image, so staying
 # with the latest (v2.9.2).
+# https://hub.docker.com/r/uselagoon/kubectl-build-deploy-dind/tags
+# Rumors will have it that this thing is no longer used or at the very least
+# will be deprecated soon. We should keep an eye on what happens in the future
+# releases of lagoon-remote.
 BUILD_DEPLOY_DIND_IMAGE_VER=v2.9.2

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -4,7 +4,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   dns_prefix          = var.environment_name
-  kubernetes_version  = var.kubernetes_version
+  kubernetes_version  = var.control_plane_version
 
   # We use a single manually scaled node pool in a single availabillity zone.
   default_node_pool {
@@ -20,6 +20,8 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
     # Attach the cluster to our private network.
     vnet_subnet_id = azurerm_subnet.aks.id
+
+    orchestrator_version = var.pool_system_version
 
     # High Avaiabillity is not a high enough priority to warrent the extra
     # complexity and cost of having a multi-zonal cluster.
@@ -65,6 +67,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "admin" {
   name                  = "admin"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cluster.id
   vnet_subnet_id        = azurerm_subnet.aks.id
+  orchestrator_version  = var.pool_admin_version
   node_labels = {
     "noderole.dplplatform" : "admin"
   }
@@ -94,6 +97,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "app_default" {
   name                  = "appdefault"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cluster.id
   vnet_subnet_id        = azurerm_subnet.aks.id
+  orchestrator_version  = var.pool_appdefault_version
   node_labels = {
     "noderole.dplplatform" : "application"
   }

--- a/infrastructure/terraform/modules/dpl-platform-environment/outputs.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/outputs.tf
@@ -3,8 +3,8 @@ output "cluster_name" {
   value       = azurerm_kubernetes_cluster.cluster.name
 }
 
-output "kubernetes_version" {
-  description = "Kubernetes version in use"
+output "control_plane_version" {
+  description = "Kubernetes control-plane version in use"
   value       = azurerm_kubernetes_cluster.cluster.kubernetes_version
 }
 

--- a/infrastructure/terraform/modules/dpl-platform-environment/providers.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/providers.tf
@@ -10,12 +10,11 @@ terraform {
     }
 
     azurerm = {
-      version = ">=3.29.0"
+      version = ">=3.33.0"
     }
 
     random = {
       version = ">=3.0.0"
     }
-
   }
 }

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -4,8 +4,8 @@ variable "base_domain" {
   default     = "reload.dk"
 }
 
-variable "kubernetes_version" {
-  description = "Which version of AKS to provision. Bump this variable to trigger an upgrade."
+variable "control_plane_version" {
+  description = "Which version of the AKS control-plane to provision. Bump this variable to trigger an upgrade."
   type        = string
 }
 
@@ -76,6 +76,21 @@ variable "node_pool_system_count" {
 variable "node_pool_system_vm_sku" {
   description = "The SKU of the virtual machines used for the system nodepool"
   default     = "Standard_B4ms"
+  type        = string
+}
+
+variable "pool_admin_version" {
+  description = "Which version Kubernetes to use for the admin node-pool. Must be compatible with control_plane_version, that is, cannot be higher and should at most trail one minor version."
+  type        = string
+}
+
+variable "pool_appdefault_version" {
+  description = "Which version Kubernetes to use for the default app node-pool. Must be compatible with control_plane_version, that is, cannot be higher and should at most trail one minor version."
+  type        = string
+}
+
+variable "pool_system_version" {
+  description = "Which version Kubernetes to use for the system node-pool. Must be compatible with control_plane_version, that is, cannot be higher and should at most trail one minor version."
   type        = string
 }
 


### PR DESCRIPTION
#### What does this PR do?
I've upgraded the cluster to kubernetes veersion 1.24.6 and lagoon to 2.11.0

The upgrade revealed that we had a need for a more nuanced handling of versions of our node-pools so I updated the Terraform setup to allow us to control the versions of the individual nodepools.

I also noticed we where using a silly volume size for harbors pvcs and updated those.

#### Should this be tested by the reviewer and how?

This PR is made after the fact, so the review is mostly about reading through the updated documentation and the changes to Terraform.

#### What are the relevant tickets?

DDFDRIFT-1
DDFDRIFT-14
