### PR TITLE
Add a runbook for scaling aks

### DIFF
--- a/documentation/runbooks/scale-aks.md
+++ b/documentation/runbooks/scale-aks.md
@@ -1,0 +1,36 @@
+# Scaling AKS
+
+## When to use
+
+When the cluster is over or underprovisioned and needs to be scaled.
+
+## Prerequisites
+
+* A running [dplsh](using-dplsh.md) launched from `./infrastructure` with
+  `DPLPLAT_ENV` set to the platform environment name.
+
+## References
+
+* For general information about AKS and node-pools <https://learn.microsoft.com/en-us/azure/aks/use-multiple-node-pools>
+
+## Procedure
+
+There are multiple approaches to scaling AKS. We run with the auto-scaler enabled
+which means that in most cases the thing you want to do is to adjust the max or
+minimum configuration for the autoscaler.
+
+* [Adjusting the autoscaler](#adjusting-the-autoscaler)
+
+### Adjusting the autoscaler
+
+Edit the infrastructure configuration for your environment. Eg for `dplplat01`
+edit `dpl-platform/dpl-platform/infrastructure/environments/dplplat01/infrastructure/main.tf`.
+
+Adjust the `*_count_min` / `*_count_min` corrospodning to the node-pool you
+want to grow/shrink.
+
+Then run `infra:provision` to have terraform effect the change.
+
+```shell
+task infra:provision
+```


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Adds a quick runbook for scaling the max/min nodepool size.

We should continue the work on this runbook as we run in to other scaling tasks.

#### Should this be tested by the reviewer and how?
Read through the runbook and see if it makes sense.

