### PR TITLE
Update grafana, cert-manager. Improve docs and tools

### DIFF
--- a/documentation/runbooks/upgrading-support-workloads.md
+++ b/documentation/runbooks/upgrading-support-workloads.md
@@ -18,13 +18,17 @@ TODO
 
 TODO
 
-## Procedure
+## General Procedure
 
 * Identify the version you want to bump in the `environment/configuration` directory
-  eg for dplplat01 [infrastructure/environments/dplplat01/configuration/versions.env](../../infrastructure/environments/dplplat01/configuration/versions.env)
+  eg for dplplat01 [infrastructure/environments/dplplat01/configuration/versions.env](../../infrastructure/environments/dplplat01/configuration/versions.env).
+  You can find the latest version of the support workload in the [Version status](https://docs.google.com/spreadsheets/d/15xLv-zhIL0g_gQaUfsslYVzAclrG-T5gkjII8mbRHoU/edit#gid=0)
+  sheet which itself is updated via the procedure described in the
+  [Update Upgrade status](update-upgrade-status.md) runbook.
 
 * Consult any relevant changelog to determine if the upgrade will require any
-  extra work beside the upgrade itself.
+  extra work beside the upgrade itself. The [Specific producedures and tests](#specific-producedures-and-tests)
+  sections may contain futher documentation for specific workloads.
 
 * Identify the relevant task in the main [Taskfile](../../infrastructure/Taskfile.yml)
   for upgrading the workload. For example, for cert-manager, the task is called
@@ -40,8 +44,84 @@ proceed with the upgrade if the user has not specified DIFF=1.
 * Then proceeded to perform the verification test for the relevant workload. See
   the following section for known verification tests.
 
-## Verification tests
+## Specific producedures and tests
 
 ### Cert Manager
 
-TODO
+#### Upgrade cert-manager
+
+Commands
+
+```bash
+# Diff
+DIFF=1 task support:provision:cert-manager
+
+# Upgrade
+task support:provision:cert-manager
+```
+
+#### Verify cert-manager upgrade
+
+Verify that cert-manager itself and webhook pods are all running and healthy.
+
+```bash
+task support:verify:cert-manager
+```
+
+### Grafana
+
+#### Upgrade grafana
+
+Charts and app releases has wildly different versions, so you should always look
+at the diff between both the chart and app version.
+
+The general upgrade procedure will give you the chart version, access the
+following link to get the release note for the chart. Remember to insert your
+version:
+
+<https://github.com/grafana/helm-charts/releases/tag/grafana-6.52.9>
+
+The note will most likely be empty. Now diff the chart version with the current
+version, again replacing the version with the relevant for your releases.
+
+<https://github.com/grafana/helm-charts/compare/grafana-6.43.3...grafana-6.52.9>
+
+As the repository contains a lot of charts, you will need to do a bit of
+digging. Look for at least `charts/grafana/Chart.yaml` which can tell you the
+app version.
+
+With the app-version in hand, you can now look at the release notes for [the
+grafana app](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)
+itself.
+
+Diff command
+
+```bash
+DIFF=1 task support:provision:grafana
+```
+
+Upgrade command
+
+```bash
+task support:provision:grafana
+```
+
+#### Verify grafana upgrade
+
+Verify that the Grafana pods are all running and healthy.
+
+```bash
+kubectl get pods --namespace grafana
+```
+
+Access the Grafana UI and see if you can log in. If you do not have a user
+but have access to read secrets in the `grafana` namespace, you can retrive the
+admin password with the following command:
+
+```bash
+# Password for admin
+UI_NAME=grafana task ui-password
+
+# Hostname for grafana
+kubectl -n grafana get -o jsonpath="{.spec.rules[0].host}" ingress grafana ; echo
+```

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -48,6 +48,17 @@ tasks:
       cmds:
         - terraform init -upgrade
 
+    infra:terraform:init-upgrade:
+      desc: Init and upgrade local Terraform state
+      summary: |
+        Use this task the local state needs to be updated. This happens eg. when
+        terraform is upgraded.
+      deps:
+        - _req_env
+      dir: "{{.dir_infra}}"
+      cmds:
+        - terraform init -upgrade
+
     infra:terraform:output:
       deps: [_req_env, _infra:terraform:init]
       cmds:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -157,6 +157,14 @@ tasks:
       cmds:
         - task/scripts/provision-cert-manager.sh
 
+    support:verify:cert-manager:
+      deps: [cluster:auth]
+      summary: Verify cert-manager
+      desc: Attempts to verify that cert-manager is installed and configured correctly.
+      cmds:
+        - cm-verifier
+        - kubectl get pods --namespace cert-manager
+
     support:provision:ingress-nginx:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.

--- a/infrastructure/environments/dplplat01/configuration/versions.env
+++ b/infrastructure/environments/dplplat01/configuration/versions.env
@@ -1,11 +1,12 @@
 # Versions of our support workloads
 # Version-references in this file MUST be on the form VERSION_*
 
-# https://artifacthub.io/packages/helm/cert-manager/cert-manager
-VERSION_CERT_MANAGER=v1.11.0
+# https://artifacthub.io/packages/helm/cert-manager/cert-m
+# https://github.com/cert-manager/cert-manager/releases
+VERSION_CERT_MANAGER=v1.11.1
 
 # https://artifacthub.io/packages/helm/grafana/grafana
-VERSION_GRAFANA=6.43.3
+VERSION_GRAFANA=6.52.8
 
 # https://artifacthub.io/packages/helm/harbor/harbor
 VERSION_HARBOR=1.10.1

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -74,7 +74,7 @@ COPY --from=helm /usr/bin/helm /usr/bin/
 RUN ( \
     set -x; cd "$(mktemp -d)" && \
     OS="$(uname)" && \
-    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
+    ARCH="$(uname -m | sed -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
     ARTIFACT_NAME="cert-manager-verifier_${CERT_MANAGER_VERIFIER_VERSION}_${OS}_${ARCH}.tar.gz" && \
     curl -fsSLO "https://github.com/alenkacz/cert-manager-verifier/releases/download/v${CERT_MANAGER_VERIFIER_VERSION}/${ARTIFACT_NAME}" && \
     tar zxvf "${ARTIFACT_NAME}" && \

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -20,6 +20,10 @@ ARG STERN_RELEASE=1.21.0
 ARG LAGOON_CLI_RELEASE=v0.14.0
 # See https://github.com/kubernetes-sigs/krew/releases
 ARG KREW_VERSION=v0.4.3
+# https://github.com/alenkacz/cert-manager-verifier/releases
+# Exclude the "v" from the version.
+ARG CERT_MANAGER_VERIFIER_VERSION=0.3.0
+
 # This version can be bumped as we upgrade the cluster minor version.
 ARG KUBECTL_VERSION=v1.20.9
 
@@ -65,6 +69,17 @@ COPY --from=terraform /bin/terraform /bin/
 
 # Add Helm
 COPY --from=helm /usr/bin/helm /usr/bin/
+
+# Add cert-manager verifyer
+RUN ( \
+    set -x; cd "$(mktemp -d)" && \
+    OS="$(uname)" && \
+    ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
+    ARTIFACT_NAME="cert-manager-verifier_${CERT_MANAGER_VERIFIER_VERSION}_${OS}_${ARCH}.tar.gz" && \
+    curl -fsSLO "https://github.com/alenkacz/cert-manager-verifier/releases/download/v${CERT_MANAGER_VERIFIER_VERSION}/${ARTIFACT_NAME}" && \
+    tar zxvf "${ARTIFACT_NAME}" && \
+    mv ./cm-verifier /usr/bin/ \
+  )
 
 # Create a dplsh user and switch to it to avoid running the shell as root
 RUN adduser -D --shell /bin/bash dplsh

--- a/tools/dplsh/README.md
+++ b/tools/dplsh/README.md
@@ -57,7 +57,7 @@ shell. The shell will set its file-system root after the first profile it
 findes by traversing up towards the root of the host file-system. It then
 sources the file before starting the actual shell.
 
-### Example 1
+#### Example 1
 
 ```shell
 touch /project/.dplsh.profile.my-profile
@@ -74,7 +74,7 @@ dplsh -p my-profile
 
 Notice, CWD while sourcing is the subdirectory the shell was launched for in.
 
-### Example 2
+#### Example 2
 
 ```shell
 touch /project/.dplsh.profile
@@ -84,7 +84,7 @@ dplsh
 
 Same as example 1, but the shell will now default to .dplsh.profile
 
-### Example 3
+#### Example 3
 
 ```shell
 touch /project/subdir/.dplsh.profile
@@ -95,6 +95,16 @@ dplsh
 Same as example 1, but the shell will now mount /project/subdir as
 /home/dplsh/host_mount thus "jailing" the shell inside the directory it was
 launched from.
+
+### Updating the shell
+
+You can have the shell pull the latest version of itself via the `--update`
+argument. Be aware though that this will not update the `dplsh.sh` script
+that is used to launch the shell. If the shells update includes a change in
+this script, you will need to do a git pull of the repository.
+
+This is not an issue if you launch the shell via the streaming method described
+in the "Launching the shell" section.
 
 ## Troubleshooting
 

--- a/tools/dplsh/dplsh.sh
+++ b/tools/dplsh/dplsh.sh
@@ -19,7 +19,7 @@ find-up () {
 }
 
 PROFILE_FILE=
-DOCKER_IMAGE="${DPLSH_IMAGE:-ghcr.io/danskernesdigitalebibliotek/dpl-platform/dplsh:latest}"
+CONTAINER_IMAGE="${DPLSH_IMAGE:-ghcr.io/danskernesdigitalebibliotek/dpl-platform/dplsh:latest}"
 CHDIR=
 SHELL_ROOT="${PWD}"
 
@@ -71,6 +71,12 @@ if ! command -v realpath > /dev/null 2>&1; then
     realpath() { _realpath "$@"; }
 fi
 
+if [[ $# -gt 0 && $1 == "--update" ]] ; then
+  docker pull "${CONTAINER_IMAGE}"
+  echo "update done"
+  exit 0
+fi
+
 # Fix docker socket
 if [[ $# -gt 0 && $1 == "--fix-docker" ]] ; then
 
@@ -91,7 +97,7 @@ if [[ $# -gt 0 && $1 == "--fix-docker" ]] ; then
     --rm \
     --mount "type=bind,src=/var/run/docker.sock,target=/var/run/docker.sock" \
     --user root \
-    "${DOCKER_IMAGE}" chown dplsh /var/run/docker.sock
+    "${CONTAINER_IMAGE}" chown dplsh /var/run/docker.sock
 
     # Strip away the arg and continue.
     shift
@@ -220,4 +226,4 @@ docker run --hostname=dplsh \
     -v "${HOME}/.ssh:/opt/.ssh-host:ro" \
     -v "${SHELL_ROOT}:/home/dplsh/host_mount" \
     -w "/home/dplsh/host_mount/${CHDIR}" \
-    "${DOCKER_IMAGE}" "$@"
+    "${CONTAINER_IMAGE}" "$@"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
I'm working on streamlining our update procedure, and this is one of many steps towards that goal.

I've updated cert-manager and grafana, and documented the process. During my work I also implemented
a simple update-feature in dplsh, made is possible to run terraform init, and added a tool to dplsh
that allows us to verify cert-manager.

#### Should this be tested by the reviewer and how?
Mostly review of the docs, but you can also

- Check out the branch and verify that running `dplsh.sh --update` pulles the latest version of the image
- See that `task support:verify:cert-manager` works inside a shell

#### Any specific requests for how the PR should be reviewed?
Mostly, just read through it and consider if it is in a state where you would be ok with taking the reigns.

#### What are the relevant tickets?
