### PR TITLE
Update lagoon images. The previous version is 2 years old.

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ENVIRONMENT_REPO_ORG=danishpubliclibraries
-LAGOON_IMAGES_RELEASE_TAG="21.9.0"
+LAGOON_IMAGES_RELEASE_TAG="24.1.0"
 
 # Echo the second argument Exit 1 if the first argument is not 0
 # Use this function to process $? after an invocation of something that might


### PR DESCRIPTION
The old  [lagoon images ](https://github.com/uselagoon/lagoon-images/tree/main)version breaks with the php 8.1 images
The lagoon images version tag we use in dpl-cms is just latest:
https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/develop/lagoon/cli.dockerfile#L1