### PR TITLE
Bump client_max_body_size - DDFDRIFT-32

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -8,6 +8,11 @@ controller:
       "bytes_sent": $bytes_sent, "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol",
       "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer",
       "http_user_agent": "$http_user_agent" }'
+    # Default client_max_body_size is 1m, which is too small for our needs.
+    # We align this with the value in Lagoon itself.
+    # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
+    # and https://github.com/uselagoon/lagoon-images/blob/main/images/nginx/nginx.conf#L81
+    proxy-body-size: "2048m"
   replicaCount: 2
   service:
     loadBalancerIP: "${INGRESS_IP}"

--- a/infrastructure/environments/dplplat01/configuration/versions.env
+++ b/infrastructure/environments/dplplat01/configuration/versions.env
@@ -12,7 +12,7 @@ VERSION_GRAFANA=7.0.17
 VERSION_HARBOR=1.13.1
 
 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
-VERSION_INGRESS_NGINX=4.8.4
+VERSION_INGRESS_NGINX=4.9.1
 
 # https://artifacthub.io/packages/helm/appuio/k8up
 # appVersion 1.2.0


### PR DESCRIPTION

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

- Bump client_max_body_size in our Ingress controller config.
- Upgrade ingress-nginx to latest release.

#### Should this be tested by the reviewer and how?

This is already deployed to `dplplat01` and has been tested.


#### What are the relevant tickets?

DDFDRIFT-32