### PR TITLE
Install openssh in dplsh to ensure we can run ssh-related commands inside it

### DIFF
--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -46,7 +46,8 @@ RUN apk add --no-cache \
   rsync \
   shadow \
   vim \
-  yq
+  yq \
+  openssh
 
 # Add task, a modern Make equivalent.
 RUN curl -sL https://taskfile.dev/install.sh | bash -s -- -b /usr/local/bin ${TASK_VERSION}


### PR DESCRIPTION
#### What does this PR do?

The guide in [the guide for provisioning Github repos step 2](https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/add-library-site-to-platform/#step-2-provision-a-github-repository) suggests running `ssh-agent` and `ssh-add` inside dplsh, but these do not work as openssh is missing from the shell.

To make it easier to run everything inside the shell, we add the missing dependency, so the guide is now correct.

#### Should this be tested by the reviewer and how?

Build dplsh locally (`docker build . -t dplsh:local` in the /tools/dplsh folder, run the dplsh (`DPLSH_IMAGE=dplsh:local ../tools/dplsh/dplsh.sh` in the /infrastructure folder) and verify that `ssh-agent` and `ssh-add` execute without errors in the shell.

#### Any specific requests for how the PR should be reviewed?

N/A

#### What are the relevant tickets?

N/A