### PR TITLE
Guide adjustments

### DIFF
--- a/docs/architecture/alertmanager-setup.md
+++ b/docs/architecture/alertmanager-setup.md
@@ -1,6 +1,6 @@
 # Alertmanager Setup
 
-The We use the [alertmanager](architecture/adr-003-system-alerts.md) automatically
+We use the [alertmanager](architecture/adr-003-system-alerts.md) which automatically
 ties to the metrics of Prometheus but in order to make it work the configuration
 and rules need to be setup.
 

--- a/docs/runbooks/add-generic-site-to-platform.md
+++ b/docs/runbooks/add-generic-site-to-platform.md
@@ -15,8 +15,11 @@ which is used to develop the shared DPL install profile.
   permissions to the platforms azure infrastructure.
 * A running [dplsh](using-dplsh.md) with `DPLPLAT_ENV` set to the platform
   environment name.
-* A Lagoon account on the Lagoon core with your ssh-key associated
-* The git-url for the sites environment repository
+* A Lagoon account on the Lagoon core with your ssh-key associated (created through
+  the Lagoon UI, on the Settings page)
+* The git-url for the sites environment repository (you don't need to create this
+  repository - it will be created by the task below - but the URL must match the
+  Github repository that will be created)
 * A personal access-token that is allowed to pull images from the image-registry
   that hosts our images.
 * The platform environment name (Consult the [platform environment documentation](https://github.com/danskernesdigitalebibliotek/dpl-platform/wiki/Platform-Environments))

--- a/docs/runbooks/add-library-site-to-platform.md
+++ b/docs/runbooks/add-library-site-to-platform.md
@@ -76,8 +76,11 @@ Run `task env_repos:provision` to create the repository.
 
 Prerequisites:
 
-* A Lagoon account on the Lagoon core with your ssh-key associated
-* The git-url for the sites environment repository
+* A Lagoon account on the Lagoon core with your ssh-key associated (created through
+  the Lagoon UI, on the Settings page)
+* The git-url for the sites environment repository (you don't need to create this
+  repository - it will be created by the task below - but the URL must match the
+  Github repository that will be created)
 * A personal access-token that is allowed to pull images from the image-registry
   that hosts our images.
 * The platform environment name (Consult the [platform environment documentation](https://github.com/danskernesdigitalebibliotek/dpl-platform/wiki/Platform-Environments))

--- a/docs/runbooks/remove-site-from-platform.md
+++ b/docs/runbooks/remove-site-from-platform.md
@@ -8,7 +8,8 @@ Prerequisites:
 
 * The platform environment name
 * An user with administrative access to the environment repository
-* A lagoon account with your ssh-key associated
+* A lagoon account with your ssh-key associated (created through
+  the Lagoon UI, on the Settings page)
 * The site key (its key in [sites.yaml](../architecture/platform-environment-architecture.md#sitesyaml))
 * An properly authenticated azure CLI (`az`) that has administrative access to
   the cluster running the lagoon installation

--- a/infrastructure/terraform/modules/dpl-platform-env-repos/lagoon_integration.tf
+++ b/infrastructure/terraform/modules/dpl-platform-env-repos/lagoon_integration.tf
@@ -1,4 +1,4 @@
-# Register a webhook pr repository that will let Lagoon react on pushes and
+# Register a webhook per repository that will let Lagoon react on pushes and
 # pull-requests.
 resource "github_repository_webhook" "lagoon_deploy" {
   for_each = local.sites


### PR DESCRIPTION
Draft because this is WIP as we run through runbooks and try to use them.

- Lagoon ssh keys as a prerequisite now also list where to create those keys
- When creating a site, a git-url must be provided - it is now clarified that the repo it points to does not need to exist before running the tasks in the runbook.

#### Should this be tested by the reviewer and how?

Read and verify the changes improve clarity, while staying as concise as possible.

#### What are the relevant tickets?

N/A