### PR TITLE
Back up at midday and again in the evening

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -82,4 +82,4 @@ backup-retention:
     hourly: 0
 # https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#backup-schedule
 backup-schedule:
-  production: M 12,19 * * *
+  production: M H(12-14),H(19-21) * * *

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -82,4 +82,4 @@ backup-retention:
     hourly: 0
 # https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#backup-schedule
 backup-schedule:
-  production: M H(22-2) * * *
+  production: M 12,19 * * *

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -74,9 +74,9 @@ container-registries:
 backup-retention:
   # Configure the number of monthly, weekly, daily and hourly backups to retain.
   production:
-    monthly: 1
-    weekly: 6
-    daily: 7
+    monthly: 2
+    weekly: 10
+    daily: 12
     # Be aware that hourly backups are only possible if the backup schedule is
     # adjusted to run every hour.
     hourly: 0


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
DDF wants two daily backups to be made; one around lunch and another in the evening. 
This PR changes the backup scheduling from running in the late evening to running at 12:00 and again at 19:00.

#### Should this be tested by the reviewer and how?
I don't see any good path to test this outside of the production envs. We should however have a look at the backup being made the day this PR is merged in. 

#### Any specific requests for how the PR should be reviewed?
Ensure that the times entered at the hours place is 12 and 19.

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-35