### PR TITLE
Add CMS school site

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -15,6 +15,11 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.12.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFcUB4bJlX+B7upLuiOzT/3eju6l8zvor6VVmPz4n8Hp"
+  cms-school:
+    name: "CMS-skole"
+    description: "Et site til undervisning i CMSet"
+    deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
+    << : *default-release-image-source
   kobenhavn:
     name: "Københavns Biblioteker"
     description: "The main library site for København"


### PR DESCRIPTION
#### What does this PR do?

Adds a site for teaching how to use the CMS. Like a pilot site, but not running a particular library.

#### Should this be tested by the reviewer and how?

The adding and deploying runbooks have been run. Verify that the site is running correctly.

#### What are the relevant tickets?

[DDFDRIFT-57](https://reload.atlassian.net/browse/DDFDRIFT-57?atlOrigin=eyJpIjoiNGZkMjdlMTVmMzM3NGM0NDg4MGFmOGU4OTAwN2FmZGQiLCJwIjoiaiJ9)

[DDFDRIFT-57]: https://reload.atlassian.net/browse/DDFDRIFT-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ