### PR TITLE
Enable sshCore in lagoon-remote chart

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -15,6 +15,10 @@ lagoon-build-deploy:
   taskSSHPort: "22"
   taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
   lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
+
+sshCore:
+  enabled: true
+
 dbaas-operator:
   enabled: true
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Enabling `sshCore` creates a service account which can be used by the lagoon-core-ssh service to provide ssh access to the projects. This, in turn, is required for running lagoon-sync, which executes inside the projects.

The changes have already been applied in the cluster. Here is the diff produced from applying the helm chart:

```diff
lagoon, lagoon-remote-ssh-core, ClusterRole (rbac.authorization.k8s.io) has been added:
- 
+ # Source: lagoon-remote/templates/ssh-core.clusterrole.yaml
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRole
+ metadata:
+   name: lagoon-remote-ssh-core
+   labels:
+     helm.sh/chart: lagoon-remote-0.87.0
+     app.kubernetes.io/name: lagoon-remote
+     app.kubernetes.io/component: lagoon-remote-ssh-core
+     app.kubernetes.io/instance: lagoon-remote
+     app.kubernetes.io/managed-by: Helm
+ rules:
+ - apiGroups:
+   - apps
+   resources:
+   - deployments/scale
+   verbs:
+   - get
+   - update
+ - apiGroups:
+   - apps
+   resources:
+   - deployments
+   verbs:
+   - get
+   - list
+ - apiGroups:
+   - ""
+   resources:
+   - pods
+   verbs:
+   - get
+   - list
+ - apiGroups:
+   - ""
+   resources:
+   - pods/exec
+   verbs:
+   - create
lagoon, lagoon-remote-ssh-core, ClusterRoleBinding (rbac.authorization.k8s.io) has been added:
- 
+ # Source: lagoon-remote/templates/ssh-core.clusterrolebinding.yaml
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRoleBinding
+ metadata:
+   name: lagoon-remote-ssh-core
+   labels:
+     helm.sh/chart: lagoon-remote-0.87.0
+     app.kubernetes.io/name: lagoon-remote
+     app.kubernetes.io/component: lagoon-remote-ssh-core
+     app.kubernetes.io/instance: lagoon-remote
+     app.kubernetes.io/managed-by: Helm
+ subjects:
+ - kind: ServiceAccount
+   name: lagoon-remote-ssh-core
+   namespace: "lagoon"
+ roleRef:
+   kind: ClusterRole
+   name: lagoon-remote-ssh-core
+   apiGroup: rbac.authorization.k8s.io
lagoon, lagoon-remote-ssh-core, ServiceAccount (v1) has been added:
- 
+ # Source: lagoon-remote/templates/ssh-core.serviceaccount.yaml
+ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: lagoon-remote-ssh-core
+   labels:
+     helm.sh/chart: lagoon-remote-0.87.0
+     app.kubernetes.io/name: lagoon-remote
+     app.kubernetes.io/component: lagoon-remote-ssh-core
+     app.kubernetes.io/instance: lagoon-remote
+     app.kubernetes.io/managed-by: Helm
lagoon, lagoon-remote-ssh-core-token, Secret (v1) has been added:
+ # Source: lagoon-remote/templates/ssh-core.secret.yaml
+ apiVersion: v1
+ kind: Secret
+ metadata:
+   annotations:
+     kubernetes.io/service-account.name: lagoon-remote-ssh-core
+   labels:
+     app.kubernetes.io/component: lagoon-remote-ssh-core
+     app.kubernetes.io/instance: lagoon-remote
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: lagoon-remote
+     helm.sh/chart: lagoon-remote-0.87.0
+   name: lagoon-remote-ssh-core-token
+ type: kubernetes.io/service-account-token
```

#### Should this be tested by the reviewer and how?

Given an authenticated lagoon CLI, verify that you can get an ssh session on the `cli`-pod of an environment by running `lagoon ssh --project <project> --environment <env>`.

#### What are the relevant tickets?

[DDFDRIFT-36](https://reload.atlassian.net/browse/DDFDRIFT-36)

[DDFDRIFT-36]: https://reload.atlassian.net/browse/DDFDRIFT-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ