### PR TITLE
Deploy 2024.15.0 on canary

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -13,7 +13,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.12.0"
+    dpl-cms-release: "2024.15.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFcUB4bJlX+B7upLuiOzT/3eju6l8zvor6VVmPz4n8Hp"
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
#### What does this PR do?

Releases 2024.15.0 on canary. Has already been executed with `task site:sync SITE=canary`

#### Should this be tested by the reviewer and how?

Verify canary site looks to be running correct version.

#### What are the relevant tickets?

[DDFDRIFT-53](https://reload.atlassian.net/browse/DDFDRIFT-53?atlOrigin=eyJpIjoiYWE3NDEwNTY2NWM1NGI3MGE4YzgyNmJmMmY4MTA4M2EiLCJwIjoiaiJ9)

[DDFDRIFT-53]: https://reload.atlassian.net/browse/DDFDRIFT-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ