### PR TITLE
Release dpl-cms 2024.17.0 to all sites

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -532,7 +532,7 @@ tasks:
       vars:
         ENVIRONMENT_NAME_INPUT:
           sh: |
-            if [ -z \"{{.ENVIRONMENT_NAME}}\" ]; then
+            if [ ! -z \"{{.ENVIRONMENT_NAME}}\" ]; then
               echo -n "";
             else
               echo -n 'environment: \"{{.ENVIRONMENT_NAME}}\",';

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.15.1"
+  dpl-cms-release: "2024.17.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Releases [dpl-cms@2024.17.0](https://github.com/danskernesdigitalebibliotek/dpl-cms/releases/tag/2024.17.0) to all sites.

This has been tested on the canary site since yesterday.

Will be executed at 14:00

#### What are the relevant tickets?

[DDFDRIFT-84](https://reload.atlassian.net/browse/DDFDRIFT-84?atlOrigin=eyJpIjoiNDBiZjllZTJjMDk2NDgyYWE0ZTIyMzJiNTVhZWZmNzYiLCJwIjoiaiJ9)

[DDFDRIFT-84]: https://reload.atlassian.net/browse/DDFDRIFT-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ