### PR TITLE
Various task stuff

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -142,7 +142,17 @@ tasks:
                 )
               --query value -o tsv
       cmds:
-        - cmd: terraform -chdir={{.dir_env_repos}} import "{{.OPTIONS}}" "{{.ADDRESS_ID}}"
+        - cmd: terraform -chdir={{.dir_env_repos}} import '{{.OPTIONS}}' '{{.ADDRESS_ID}}'
+
+    terraform:import:repo:
+      desc: Imports a Github repository for a site by passing the site name
+      cmds:
+        - task: terraform:import
+          vars:
+            OPTIONS: module.env_repos.github_repository.site["{{.SITE}}"]
+            ADDRESS_ID: env-{{.SITE}}
+      preconditions:
+      - *require_site
 
     cluster:auth:
         deps: [_req_env, _infra:terraform:init]

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -707,9 +707,6 @@ tasks:
         - task: lagoon:project:ensure:github-registry-credentials
           vars:
             PROJECT_NAME: "{{.PROJECT_NAME}}"
-        - task: lagoon:project:deploykey
-          vars:
-            PROJECT_NAME: "{{.PROJECT_NAME}}"
       preconditions:
       - sh: "[ ! -z {{.GIT_URL}} ]"
         msg: "Env variable GIT_URL is not set or empty."

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -865,6 +865,24 @@ tasks:
       cmds:
         - cat sites.yaml | yq '.sites | keys | .[]'
 
+    sites:check:
+      desc: Simply checks that all sites defined in sites.yaml are running and responding
+      dir: "{{.dir_env}}"
+      vars:
+        sites:
+          sh: cat {{.dir_env}}/sites.yaml | yq '.sites | keys | .[]'
+      cmds:
+        - touch statusnow.txt
+        - for: { var: sites }
+          cmd: |
+            if [[ "$(curl -I https://varnish.main.{{.ITEM}}.dplplat01.dpl.reload.dk | head -1)" == "HTTP/2 200"* ]]; then
+              echo "{{.ITEM}}: OK" >> statusnow.txt;
+            else
+              echo "{{.ITEM}}: ERROR! Not up." >> statusnow.txt;
+            fi
+        - cat statusnow.txt
+        - rm statusnow.txt
+
     sites:sync:
       desc: Performs a full synchronization from sites.yaml to running state
       dir: "{{.dir_env}}"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Cleans up task things:
- adds sites:check which shows a report on which sites from sites.yaml are responding correctly on /
- adds a task for terraform importing a github repo by site name (which also serves to document how we import resources in modules so we dont forget again - it is complex!)
- removes step that prints deploykey when syncing sites - we capture it, but no longer need it as output.

#### Should this be tested by the reviewer and how?

Run sites:check and see that it makes sense.

#### What are the relevant tickets?

[DDFDRAFT-75](https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiMzQ1MDU2OTE2YzUwNGNlNjkwZWI2NTUyMTZiYTQxNmQiLCJwIjoiaiJ9)