### PR TITLE
Deploy 2024.18.0 to canary

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -12,7 +12,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.17.0"
+    dpl-cms-release: "2024.18.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Releases 2024.18.0 to canary. It has [already been run](https://github.com/danishpubliclibraries/env-canary/commit/1a642e552b5ed8f9762ccf35568b7d90f1474115)

#### What are the relevant tickets?

[DDFDRIFT-75](https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiNDc3YzE0NGRlZmVhNGZjZDg4MTI5ODdmNDI1Yzk5MmUiLCJwIjoiaiJ9)

[DDFDRIFT-75]: https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ