### PR TITLE
Zerossl cert issuer

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -191,6 +191,25 @@ tasks:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.
       desc: Install and configure cert-manager
+      env:
+        ZEROSSL_EAB_SECRET_KEY_ID:
+          sh: az keyvault secret show
+              --subscription "{{.AZURE_SUBSCRIPTION_ID}}"
+              --name zerossl-eabsecret-kid
+              --vault-name
+                $(
+                  terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)"
+                )
+              --query value -o tsv
+        ZEROSSL_EAB_SECRET:
+          sh: az keyvault secret show
+              --subscription "{{.AZURE_SUBSCRIPTION_ID}}"
+              --name zerossl-eabsecret
+              --vault-name
+                $(
+                  terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".keyvault_name.value | select (.!=null)"
+                )
+              --query value -o tsv
       cmds:
         - task/scripts/provision-cert-manager.sh
 

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/.gitignore
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/.gitignore
@@ -1,0 +1,3 @@
+# Ignore rendered templates
+zerossl-eabsecret.yaml
+zerossl-issuer-production.yaml

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/cert-manager-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/cert-manager-values.yaml
@@ -1,5 +1,5 @@
 installCRDs: true
 ingressShim:
-  defaultIssuerName: letsencrypt-prod
+  defaultIssuerName: zerossl-production
   defaultIssuerKind: ClusterIssuer
   defaultIssuerGroup: cert-manager.io

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zero-ssl-eabsecret
+data:
+  secret: ZEROSSL_EAB_SECRET

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
@@ -3,4 +3,4 @@ kind: Secret
 metadata:
   name: zero-ssl-eabsecret
 data:
-  secret: ZEROSSL_EAB_SECRET
+  secret: $ZEROSSL_EAB_SECRET

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-issuer-production.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-issuer-production.template.yaml
@@ -14,7 +14,7 @@ spec:
 
     # for each cert-manager new EAB credencials are required
     externalAccountBinding:
-      keyID: ZEROSSL_EAB_SECRET_KEY_ID
+      keyID: $ZEROSSL_EAB_SECRET_KEY_ID
       keySecretRef:
         name: zerossl-eabsecret
         key: secret

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-issuer-production.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-issuer-production.template.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: zerossl-production
+spec:
+  acme:
+    # ZeroSSL ACME server
+    server: https://acme.zerossl.com/v2/DV90
+    email: security+certmgr+dplplat01@reload.dk
+
+    # name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: zerossl-acme-account-key-prod
+
+    # for each cert-manager new EAB credencials are required
+    externalAccountBinding:
+      keyID: ZEROSSL_EAB_SECRET_KEY_ID
+      keySecretRef:
+        name: zerossl-eabsecret
+        key: secret
+      keyAlgorithm: HS256
+
+    # ACME DNS-01 provider configurations to verify domain
+    solvers:
+    - http01:
+       ingress:
+         class: nginx

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -12,7 +12,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.17.0"
+    dpl-cms-release: "2024.18.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Sets up a zerossl-based ACME cert issuer and starts using it has the primary issuer.

This lets us issue more certs, which we need because we've hit the LetsEncrypt rate limit.

This extends provision-cert-manager.sh to make it do all the things required for zerossl's issuer to work.

#### Should this be tested by the reviewer and how?

Read the code, does it seem reasonable?

Run `DIFF=1 task provision:cert-manager` and validate that the output (also pasted below for convenience) makes sense:

```diff
dplsh:~/host_mount$ DIFF=1 task support:provision:cert-manager
task: Task "_infra:terraform:init" is up to date
task: Task "cluster:auth" is up to date
task: [support:provision:cert-manager] task/scripts/provision-cert-manager.sh
 > Diffing release
cert-manager, cert-manager, Deployment (apps) has changed:
  # Source: cert-manager/templates/deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: cert-manager
    namespace: cert-manager
    labels:
      app: cert-manager
      app.kubernetes.io/name: cert-manager
      app.kubernetes.io/instance: cert-manager
      app.kubernetes.io/component: "controller"
      app.kubernetes.io/version: "v1.12.7"
      app.kubernetes.io/managed-by: Helm
      helm.sh/chart: cert-manager-v1.12.7
  spec:
    replicas: 1
    selector:
      matchLabels:
        app.kubernetes.io/name: cert-manager
        app.kubernetes.io/instance: cert-manager
        app.kubernetes.io/component: "controller"
    template:
      metadata:
        labels:
          app: cert-manager
          app.kubernetes.io/name: cert-manager
          app.kubernetes.io/instance: cert-manager
          app.kubernetes.io/component: "controller"
          app.kubernetes.io/version: "v1.12.7"
          app.kubernetes.io/managed-by: Helm
          helm.sh/chart: cert-manager-v1.12.7
        annotations:
          prometheus.io/path: "/metrics"
          prometheus.io/scrape: 'true'
          prometheus.io/port: '9402'
      spec:
        serviceAccountName: cert-manager
        securityContext:
          runAsNonRoot: true
          seccompProfile:
            type: RuntimeDefault
        containers:
          - name: cert-manager-controller
            image: "quay.io/jetstack/cert-manager-controller:v1.12.7"
            imagePullPolicy: IfNotPresent
            args:
            - --v=2
            - --cluster-resource-namespace=$(POD_NAMESPACE)
            - --leader-election-namespace=kube-system
            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.12.7
-           - --default-issuer-name=letsencrypt-prod
+           - --default-issuer-name=zerossl-production
            - --default-issuer-kind=ClusterIssuer
            - --default-issuer-group=cert-manager.io
            - --max-concurrent-challenges=60
            ports:
            - containerPort: 9402
              name: http-metrics
              protocol: TCP
            - containerPort: 9403
              name: http-healthz
              protocol: TCP
            securityContext:
              allowPrivilegeEscalation: false
              capabilities:
                drop:
                - ALL
            env:
            - name: POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
        nodeSelector:
          kubernetes.io/os: linux
 > Diffing issuers
--- /tmp/LIVE-3783849115/v1.Secret.default.zero-ssl-eabsecret
+++ /tmp/MERGED-1608977159/v1.Secret.default.zero-ssl-eabsecret
@@ -1 +1,10 @@
-null
+apiVersion: v1
+data:
+  secret: '***'
+kind: Secret
+metadata:
+  creationTimestamp: "2024-05-01T08:23:02Z"
+  name: zero-ssl-eabsecret
+  namespace: default
+  uid: 38825805-8d7f-4390-875c-133563bb4732
+type: Opaque
Warning: ACME issuer spec field 'externalAccount.keyAlgorithm' is deprecated. The value of this field will be ignored.
--- /tmp/LIVE-3413774068/cert-manager.io.v1.ClusterIssuer..zerossl-production
+++ /tmp/MERGED-3637089186/cert-manager.io.v1.ClusterIssuer..zerossl-production
@@ -0,0 +1,24 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  creationTimestamp: "2024-05-01T08:23:02Z"
+  generation: 1
+  name: zerossl-production
+  uid: 4122e30d-afbe-4d81-bb14-2f1bd3849832
+spec:
+  acme:
+    email: security+certmgr+dplplat01@reload.dk
+    externalAccountBinding:
+      keyAlgorithm: HS256
+      keyID: qgKEGtzW52ES115hQwJ2Kg
+      keySecretRef:
+        key: secret
+        name: zerossl-eabsecret
+    preferredChain: ""
+    privateKeySecretRef:
+      name: zerossl-acme-account-key-prod
+    server: https://acme.zerossl.com/v2/DV90
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
 > Done.
```

#### What are the relevant tickets?

[DDFDRIFT-75](https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiZjA3ZGE1ZWVmYjVkNDAyZGE2MjE0MWQ2YzcwYzQ5NmEiLCJwIjoiaiJ9)

[DDFDRIFT-75]: https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ