### PR TITLE
Fix zerossl-eabsecret name and location

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/cert-manager/cert-manager-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/cert-manager-values.yaml
@@ -1,5 +1,9 @@
+global:
+  logLevel: 5
+
 installCRDs: true
 ingressShim:
   defaultIssuerName: zerossl-production
   defaultIssuerKind: ClusterIssuer
   defaultIssuerGroup: cert-manager.io
+maxConcurrentChallenges: 10

--- a/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/cert-manager/zerossl-eabsecret.template.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: zero-ssl-eabsecret
+  name: zerossl-eabsecret
+  namespace: cert-manager
 data:
   secret: $ZEROSSL_EAB_SECRET


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Fixes zerossl secret name and namespace so we create it correctly

#### What are the relevant tickets?

[DDFDRIFT-75](https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiNTQ5YTgyYjk2Nzg5NDQ1Yjg2MTU2NjVjOWQzNzEyYzYiLCJwIjoiaiJ9)

[DDFDRIFT-75]: https://reload.atlassian.net/browse/DDFDRIFT-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ