### PR TITLE
Scale SSH tunnel in Lagoon Core

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
@@ -118,9 +118,14 @@ drushAlias:
           - drushalias.lagoon.dplplat01.dpl.reload.dk
 
 ssh:
+  replicaCount: 4
   service:
     type: LoadBalancer
     port: 22
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
 
 broker:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

The SSH tunnel is used for various database synchronization etc. It will be good to make sure it can handle the load we may throw at it now that we have scaled up the cluster.

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?

[DDFDRIFT-96](https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiNmRkNTE4NmE1ZWIxNDlkYzkxZTIzOGNjZTQ0NTkxMDciLCJwIjoiaiJ9)

[DDFDRIFT-96]: https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ