### PR TITLE
Enable build QoS for Lagoon

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -7,6 +7,8 @@ lagoon-build-deploy:
     - "--harbor-api=https://harbor.lagoon.dplplat01.dpl.reload.dk/api/"
     - "--harbor-username=admin"
     - "--harbor-password=$HARBOR_ADMIN_PASS"
+    - "--enable-qos"
+    - "--qos-max-builds=15"
   rabbitMQUsername: "lagoon"
   rabbitMQPassword: "$RABBITMQ_PASS"
   rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Executing many concurrent builds and hence image pushes to the in-cluster Harbor registry has shown to overload Harbor and possibly the [`docker-host` service](https://github.com/uselagoon/lagoon-service-images/tree/main/docker-host) in Lagoon.

Here we enable [a "QoS" feature in the lagoon-remote controller](https://github.com/uselagoon/remote-controller/blob/main/controllers/v1beta1/build_qoshandler.go#L22) which intentionally staggers the number of concurrent builds. 

We set the limit here to 15.

