### PR TITLE
Scale up ingresses more! perhaps

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -16,8 +16,12 @@ controller:
   replicaCount: 2
   autoscaling:
     enabled: true
-    minReplicas: 2
-    maxReplicas: 10
+    minReplicas: 5
+    maxReplicas: 15
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 300Mi
   service:
     loadBalancerIP: "${INGRESS_IP}"
     externalTrafficPolicy: "Local"

--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -20,8 +20,8 @@ controller:
     maxReplicas: 15
   resources:
     requests:
-      cpu: 1000m
-      memory: 300Mi
+      cpu: 500m
+      memory: 500Mi
   service:
     loadBalancerIP: "${INGRESS_IP}"
     externalTrafficPolicy: "Local"


### PR DESCRIPTION
#### What does this PR do?

We scaled to max 10 ingresses and the autoscaler immediately went to the limit. We will see if they stay there after the 5 minute stabilization window. If they do, or even if they stay close to (say 8+) it may be worth scaling the resources instead.

This commit suggests how to do that, while also increasing the autoscaling range to a more realistic one for our load.

#### Should this be tested by the reviewer and how?

Does this policy look reasonable?

The default resources section for ingresses looks like this:

```yaml
    requests:
      cpu: 100m
      memory: 90Mi
```

So we are doing a significant increase

#### What are the relevant tickets?

[DDFDRAFT-96](https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiMjExM2Q3YjMxMGNkNDBhNmE2MDI5ZWVhNGZkNzdmYzciLCJwIjoiaiJ9)