### PR TITLE
Add task for setting up an autoscaler for a site

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -888,6 +888,18 @@ tasks:
       preconditions:
       - *require_site
 
+    site:autoscaler:
+      desc: Runs the a dpladm setup of horizontal autoscaler, making sure the site has an autoscaler configured
+      deps: [cluster:auth]
+      summary: Run the task without additional variables to see required arguments
+      env:
+        SITES_CONFIG: "{{.dir_env}}/sites.yaml"
+        SITE: "{{.SITE}}"
+      cmds:
+        - dpladm/bin/set-up-horizontal-autoscaler.sh
+      preconditions:
+      - *require_site
+
     sites:list-keys:
       desc: List keys for sites in sites.yaml config
       dir: "{{.dir_env}}"

--- a/infrastructure/dpladm/autoscaler.template.yaml
+++ b/infrastructure/dpladm/autoscaler.template.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-nginx-autoscaler
+  namespace: ${SITE_NAME}-${SITE_ENV}
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: memory
+      target:
+        averageUtilization: 500
+        type: Utilization
+    type: Resource
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx

--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -215,3 +215,71 @@ function syncEnvRepo {
   git push origin "${branchName}"
 }
 
+function print_usage {
+    # Start with a more specific error-message if we're passed the name of a
+    # variable that was missing.
+    if [[ -n "${1:-}" ]]; then
+        echo "Could not find the variable ${1}"
+    fi
+    echo
+    echo "Set the following environment variables before running the script."
+    echo "  SITES_CONFIG: path to the sites.yaml that should be used for site configuration"
+    echo "  SITE:         the sites key in sites.yaml"
+    echo ""
+    echo "  FORCE:  Push even if there is no diff in which case an empty"
+    echo "          commit will be pushed."
+
+    exit 1
+}
+
+function getSitePlan {
+    local plan
+    plan=$(yq eval ".sites.${1}.plan" "${2}")
+    if [[ "${plan}" == "null" ]]; then
+        echo "standard"
+        return
+    fi
+
+    echo "${plan}"
+    return
+}
+
+function setUpHorizontalAutoscaler {
+  local siteName=$1
+  local SITES_CONFIG=$2
+  local plan=$(getSitePlan "${siteName}" "${SITES_CONFIG}")
+
+  local workspace
+  workspace="$(getCleanWorkspacePath)"
+  cd "${workspace}"
+
+  renderAutoscalers "${siteName}" "${plan}"
+  kubectl apply --recursive -f autoscalers
+}
+
+function renderAutoscalers {
+  local siteName=$1
+  local plan=$2
+
+  local scriptDir
+  scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+  mkdir autoscalers
+
+  local envs=(
+    "main"
+  )
+
+  if [ plan = "webmaster" ]; then
+    local envs=(
+      "main"
+      "moduletest"
+    )
+  fi
+
+  for env in "${envs[@]}"; do
+    export SITE_NAME="$siteName";
+    export SITE_ENV="$env";
+    envsubst '$SITE_NAME $SITE_ENV' < "${scriptDir}/../autoscaler.template.yaml" > "autoscalers/$env.yaml";
+  done
+}

--- a/infrastructure/dpladm/bin/set-up-horizontal-autoscaler.sh
+++ b/infrastructure/dpladm/bin/set-up-horizontal-autoscaler.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Reads in a sites.yaml and updates the sites environment repository to bring it
+# in sync with the configuration with regards to eg. the deployed release.
+# This will typically trigger a deployment of the site.
+#
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/dpladm-shared.source"
+
+if [[ -z "${SITES_CONFIG:-}" ]]; then
+    print_usage "SITES_CONFIG"
+fi
+
+if [[ -z "${SITE:-}" ]]; then
+    print_usage "SITE"
+fi
+
+setUpHorizontalAutoscaler "$SITE" "$SITES_CONFIG"

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -10,23 +10,6 @@ IFS=$'\n\t'
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPT_DIR}/dpladm-shared.source"
 
-function print_usage {
-    # Start with a more specific error-message if we're passed the name of a
-    # variable that was missing.
-    if [[ -n "${1:-}" ]]; then
-        echo "Could not find the variable ${1}"
-    fi
-    echo
-    echo "Set the following environment variables before running the script."
-    echo "  SITES_CONFIG: path to the sites.yaml that should be used for site configuration"
-    echo "  SITE:         the sites key in sites.yaml"
-    echo ""
-    echo "  FORCE:  Push even if there is no diff in which case an empty"
-    echo "          commit will be pushed."
-
-    exit 1
-}
-
 function getSiteConfig {
     local config
     config=$(yq eval ".sites.${1}" "${2}")
@@ -74,18 +57,6 @@ function getSiteReleaseImageName {
     fi
 
     echo "${imageName}"
-    return
-}
-
-function getSitePlan {
-    local plan
-    plan=$(yq eval ".sites.${1}.plan" "${2}")
-    if [[ "${plan}" == "null" ]]; then
-        echo "standard"
-        return
-    fi
-
-    echo "${plan}"
     return
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

The autoscaler handles scaling the nginx pod (which runs php and nginx) for a particular site.

This means that we will automatically scale to more instances if the system reaches higher load. Makes it less likely for us to encounter downtime when we go live with sites.

The current utilizations are set based on the (for now hard-coded from lagoon's side) resource requests for the pod. As the pod only requests 110 Mi memory, we set the bar for scaling up very high (500% of request -> 550 Mi). We are in talks with Amazee about enabling changes to the resource requests but it is not currently possible.

The autoscaler has been deployed on canary, herlev, billund and kobenhavn.

#### Should this be tested by the reviewer and how?

Run the script for a site, e.g. `customizable-canary`, and verify that a horizontalpodautoscaler is created in the correct namespace.

If you really want to test it, tweak the scaling metric (e.g. set `averageUtilization: 50` for the `memory`-metric) to see the autoscaler in action.


#### What are the relevant tickets?

[DDFDRIFT-87](https://reload.atlassian.net/browse/DDFDRIFT-87?atlOrigin=eyJpIjoiYjRhM2NmMjA5NzA1NDdiNDk4YTQyNTc5YTcyYTE3ZDkiLCJwIjoiaiJ9)

[DDFDRIFT-87]: https://reload.atlassian.net/browse/DDFDRIFT-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ