### PR TITLE
Add support for `importTranslationsCron` in sites.yaml

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -66,10 +66,12 @@ function renderProfileTemplate {
   local releaseImageRepository=$3
   # Name of the container-image that contains the built release
   local releaseImageName=$4
+  # Cron schedule for importing translations
+  local importTranslationsCron=$5
   # The primary domain of the site (optional)
-  local primaryDomain=${5:-}
+  local primaryDomain=${6:-}
   # A space-seperated list of secondary domains (optional)
-  local secondaryDomainsString=${6:-}
+  local secondaryDomainsString=${7:-}
 
   PRIMARY_DOMAIN=""
   ENABLE_ROUTES=""
@@ -112,12 +114,13 @@ EndOfMessage
   export LAGOON_IMAGES_RELEASE_TAG
   export PRIMARY_DOMAIN
   export SECONDARY_DOMAINS
+  export IMPORT_TRANSLATIONS_CRON=${importTranslationsCron}
 
   # TODO this templating could be quite a bit more flexible.
   # Tell envsubst which variables to replace. This allows other variables to
   # remain untouched.
   # shellcheck disable=SC2016
-  local variablesToSubst='$RELEASE_IMAGE_REPOSITORY $RELEASE_IMAGE_NAME $RELEASE_TAG $ENABLE_ROUTES $LAGOON_IMAGES_RELEASE_TAG $LAGOON_PROJECT_NAME $PRIMARY_DOMAIN $SECONDARY_DOMAINS'
+  local variablesToSubst='$RELEASE_IMAGE_REPOSITORY $RELEASE_IMAGE_NAME $RELEASE_TAG $ENABLE_ROUTES $LAGOON_IMAGES_RELEASE_TAG $LAGOON_PROJECT_NAME $PRIMARY_DOMAIN $SECONDARY_DOMAINS $IMPORT_TRANSLATIONS_CRON'
 
   # Loop through the files we know to contain variables that needs replacing.
   local templateFiles=(
@@ -142,8 +145,9 @@ function syncEnvRepo {
   local branchName=$3
   local releaseImageRepository=$4
   local releaseImageName=$5
-  local primaryDomain="${6:-}"
-  local secondaryDomains="${7:-}"
+  local importTranslationsCron=$6
+  local primaryDomain="${7:-}"
+  local secondaryDomains="${8:-}"
 
   # TODO, preflight checks that verifies this repository looks good to go.
   # makes most sense to do when we're doing more complicated things inside
@@ -176,7 +180,7 @@ function syncEnvRepo {
 
   # Enter the template and rendered it
   cd "${repoName}"
-  renderProfileTemplate "${siteName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${primaryDomain}" "${secondaryDomains}"
+  renderProfileTemplate "${siteName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${importTranslationsCron}" "${primaryDomain}" "${secondaryDomains}"
 
   # Detect changes
   local changedFiles

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -64,11 +64,11 @@ $SECONDARY_DOMAINS
         command: drush cron
         service: cli
       - name: import translations
-        schedule: "M H(2-5) * * *"
+        schedule: "${IMPORT_TRANSLATIONS_CRON}"
         command: drush locale-check && drush locale-update
         service: cli
       - name: import danish config translations
-        schedule: "M H(2-5) * * *"
+        schedule: "${IMPORT_TRANSLATIONS_CRON}"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-cms/translations/da.config.po
         service: cli
 

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -24,6 +24,7 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.18.3"
+    importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This adds support for configuring cron schedule for an individual site for importing translations, and sets it for cms-school, so we get hourly translation imports in that one environment.

This allows us to define custom schedules for when translations should be imported.

#### Should this be tested by the reviewer and how?

Verify that the generated [.lagoon.yml](https://github.com/danishpubliclibraries/env-cms-school/blob/main/.lagoon.yml#L66-L71) looks correct

#### What are the relevant tickets?

[DDFDRIFT-101](https://reload.atlassian.net/browse/DDFDRIFT-101?atlOrigin=eyJpIjoiZWZkMWY5ZDI2YjgzNDM0ZjhiZTdkZGE1Zjc1NjRhZjAiLCJwIjoiaiJ9)

[DDFDRIFT-101]: https://reload.atlassian.net/browse/DDFDRIFT-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ