### PR TITLE
Release 2024.18.3 to early movers, recategorize who is an early mover

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -6,7 +6,7 @@ x-defaults: &default-release-image-source
 x-early-movers: &early-movers-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.18.2"
+  dpl-cms-release: "2024.18.3"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -21,11 +21,9 @@ sites:
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
-    releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-    releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.18.3"
     importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
+    <<: *early-movers-release-image-source
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
@@ -42,7 +40,7 @@ sites:
     name: "Aalborg Bibliotekerne"
     description: "The main library site for Aalborg"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE8+vj/1goR+Y42JMD/NbL4PXM4N6DifKbRZjJdyAURp"
-    <<: *early-movers-release-image-source
+    <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
@@ -77,7 +75,7 @@ sites:
     name: "Billund Bibliotekerne og Borgerservice"
     description: "The main library site for Billund"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOsUy+dVkL+KxOYz8zSel7mNkcKrEnqDZPHmsU4sfMv/"
-    <<: *default-release-image-source
+    <<: *early-movers-release-image-source
   bornholm:
     name: "Bornholms Folkebiblioteker"
     description: "The library site for Bornholm"
@@ -207,12 +205,12 @@ sites:
     name: "Herlev Bibliotek"
     description: "The library site for Herlev"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICsQ7blUGjtlSdPU4AV7PR21o2Eqg5IMKTCFX3PV/2Mf"
-    <<: *default-release-image-source
+    <<: *early-movers-release-image-source
   herning:
     name: "Herning Bibliotekerne"
     description: "The main library site for Herning"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4LZWJFrRQQD65WohscqcmX0uqx7/zXFsK/o2tVY/9B"
-    <<: *early-movers-release-image-source
+    <<: *default-release-image-source
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"
@@ -437,7 +435,7 @@ sites:
     name: "Solrød Bibliotek og Kulturhus"
     description: "The library site for Solrød"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF1GwZ4r8QZ7Vebdqiz/mtkifrLU+ZSvlAJshdXjCh5J"
-    <<: *early-movers-release-image-source
+    <<: *default-release-image-source
   sonderborg:
     name: "Biblioteket Sønderborg"
     description: "The library site for Sønderborg"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

The early movers are now:
- cms-school
- herlev (go-live monday)
- billund (go-live monday)

The relevant site updates have been executed.

#### What are the relevant tickets?

[DDFDRIFT-102](https://reload.atlassian.net/browse/DDFDRIFT-102?atlOrigin=eyJpIjoiZDhmZWVhMzA4ZWVkNDA5ZjhiMjdlODk3NzQyMWZhZDYiLCJwIjoiaiJ9)

[DDFDRIFT-102]: https://reload.atlassian.net/browse/DDFDRIFT-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ