### PR TITLE
Scale up ingress-nginx, based on metrics

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -20,8 +20,8 @@ controller:
     maxReplicas: 15
   resources:
     requests:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 300m
+      memory: 1100Mi
   service:
     loadBalancerIP: "${INGRESS_IP}"
     externalTrafficPolicy: "Local"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Based on data from Grafana this seems like a reasonable level to request to be able to deal with spikes in traffic.

The ingresses (15!) are currently using around 300-400 Mi of memory and barely perceptible CPU. We would like to run on slightly fewer ingresses with room to scale up, so this request level (1.1Gi) should accomodate that wish.

Memory graph:

![Screen Shot 2024-05-03 at 17 23 56](https://github.com/danskernesdigitalebibliotek/dpl-platform/assets/859106/3861eb4c-499b-4623-8433-71958f6f24ac)

CPU graph:

![Screen Shot 2024-05-03 at 17 25 27](https://github.com/danskernesdigitalebibliotek/dpl-platform/assets/859106/77c0dd40-d4e9-43e8-ab44-b89d6ba80eff)

We have 16 Gb memory available on each node, and allowing an ingress to be a memory heavy instance makes sense. Even at this level, we could accomodate 14 ingresses on a node, which is a lot! So it seems reasonable.

The change has been executed and is running in the platform.

#### What are the relevant tickets?

[DDFDRIFT-96](https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiMjY1Yzk4MTBhMTQ2NGVmZGEwNGUwYmE4ZTQyYWI5ZTEiLCJwIjoiaiJ9)

[DDFDRIFT-96]: https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ