### PR TITLE
Add primary and secondary domains for billund,herlev,kobenhavn

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -82,7 +82,7 @@ function renderProfileTemplate {
   if [[ -n "${primaryDomain}" ]]; then
     ENABLE_ROUTES+=$(cat << EndOfMessage
 ${routesIndent}routes:
-${routesIndent}  - nginx:
+${routesIndent}  - varnish:
 EndOfMessage
 )
     PRIMARY_DOMAIN="${singleRouteIndent}- \"${primaryDomain}\""

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -76,6 +76,11 @@ sites:
   billund:
     name: "Billund Bibliotekerne og Borgerservice"
     description: "The main library site for Billund"
+    primary-domain: billundbib.dk
+    secondary-domains:
+      - www.billundbib.dk
+      - billundbibliotek.dk
+      - www.billundbibliotek.dk
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOsUy+dVkL+KxOYz8zSel7mNkcKrEnqDZPHmsU4sfMv/"
     <<: *default-release-image-source
   bornholm:
@@ -206,6 +211,9 @@ sites:
   herlev:
     name: "Herlev Bibliotek"
     description: "The library site for Herlev"
+    primary-domain: www.herlevbibliotek.dk
+    secondary-domains:
+      - herlevbibliotek.dk
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICsQ7blUGjtlSdPU4AV7PR21o2Eqg5IMKTCFX3PV/2Mf"
     <<: *default-release-image-source
   herning:
@@ -281,6 +289,9 @@ sites:
   kobenhavn:
     name: "Københavns Biblioteker"
     description: "The main library site for København"
+    primary-domain: bibliotek.kk.dk
+    secondary-domains:
+      - www.bibliotek.kk.dk
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
     <<: *default-release-image-source
   koge:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Sets up known primary and secondary domains for the first three sites that will go live.

This means we are ready for them to point their DNS at us!

The changes has been executed in the infrastructure.

#### What are the relevant tickets?

[DDFDRIFT-98](https://reload.atlassian.net/browse/DDFDRIFT-98)

[DDFDRIFT-98]: https://reload.atlassian.net/browse/DDFDRIFT-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ