### PR TITLE
Disable Kube{ControllerManager,Proxy,Scheduler}Down alerts in Prometheus

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
@@ -56,3 +56,9 @@ prometheus:
            requests:
            # Setup a 100Gigabyte disk for holding the metrics.
              storage: 100Gi
+
+defaultRules:
+  disabled:
+    KubeControllerManagerDown: true
+    KubeProxyDown: true
+    KubeSchedulerDown: true


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Disable Kube{ControllerManager,Proxy,Scheduler}Down alerts in Prometheus

These are standard alerts but fail when running on AKS (Azure Kubernetes Service).

#### What are the relevant tickets?

[DDFDRIFT-38](https://reload.atlassian.net/browse/DDFDRIFT-38)