### PR TITLE
Adjusted pod autoscaler for sites

### DIFF
--- a/infrastructure/dpladm/autoscaler.template.yaml
+++ b/infrastructure/dpladm/autoscaler.template.yaml
@@ -15,7 +15,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 70
+        averageUtilization: 500
         type: Utilization
     type: Resource
   minReplicas: 1


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

The base levels for nginx-php pods (requests) 110 Mi memory and 0.02 cpu (by adding the requests for the two containers). Our estimates for a "large" site is that it will use 400 Mi memory and 0.1 cpu. At that point it may make sense to scale, so we adjust levels to fit that - still a very reasonable and low level.

So we set targets for the autoscaler that match a "large" instance and start scaling at that point. This means upping the CPU scaling to 500%, which is 0.1 cpu. Even this may be a low point to start scaling at...

#### Should this be tested by the reviewer and how?

Judge the reasoning. Should we up the targets even more to avoid needless scaling? We want to be able to pack into relatively few nodes here when load is low.

#### What are the relevant tickets?

[DDFDRIFT-96](https://reload.atlassian.net/browse/DDFDRIFT-96)

[DDFDRIFT-96]: https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ