### PR TITLE
Scale prometheus storage volume

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
@@ -54,7 +54,7 @@ prometheus:
          accessModes: ["ReadWriteOnce"]
          resources:
            requests:
-           # Setup a 100Gigabyte disk for holding the metrics.
+           # Setup a disk for holding the metrics.
              storage: 500Gi
 
 defaultRules:

--- a/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
@@ -55,7 +55,7 @@ prometheus:
          resources:
            requests:
            # Setup a 100Gigabyte disk for holding the metrics.
-             storage: 100Gi
+             storage: 500Gi
 
 defaultRules:
   disabled:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Scales the disk size claimed by prometheus from 100 Gi to 500 Gi.

We have been hitting the full disk size with the metrics we are storing.

Has been executed (awaiting completion) in platform.

#### What are the relevant tickets?

[DDFDRIFT-96](https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiN2FlOGI3NTYzMDEwNDlhZDk5YTJmODBmYjYwNzY4N2IiLCJwIjoiaiJ9)

[DDFDRIFT-96]: https://reload.atlassian.net/browse/DDFDRIFT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ