### PR TITLE
add a step to remind us to update the kubectl version to match the AK…

### DIFF
--- a/docs/runbooks/upgrading-aks.md
+++ b/docs/runbooks/upgrading-aks.md
@@ -86,3 +86,4 @@ Monitor via eg.
 ```shell
 watch -n 5 kubectl get nodes
 ```
+5. Go to `dplsh's` Dockerfile and update the `kubectl` version to match that of the upgraded AKS version

--- a/docs/runbooks/upgrading-aks.md
+++ b/docs/runbooks/upgrading-aks.md
@@ -87,4 +87,5 @@ for background info on this operation.
     watch -n 5 kubectl get nodes
     ```
 
-5. Go to `dplsh's` Dockerfile and update the `KUBECTL_VERSION` version to match that of the upgraded AKS version
+5. Go to `dplsh's` Dockerfile and update the `KUBECTL_VERSION` version to
+    match that of the upgraded AKS version

--- a/docs/runbooks/upgrading-aks.md
+++ b/docs/runbooks/upgrading-aks.md
@@ -86,4 +86,4 @@ Monitor via eg.
 ```shell
 watch -n 5 kubectl get nodes
 ```
-5. Go to `dplsh's` Dockerfile and update the `kubectl` version to match that of the upgraded AKS version
+5. Go to `dplsh's` Dockerfile and update the `KUBECTL_VERSION` version to match that of the upgraded AKS version

--- a/docs/runbooks/upgrading-aks.md
+++ b/docs/runbooks/upgrading-aks.md
@@ -86,4 +86,5 @@ for background info on this operation.
     ```shell
     watch -n 5 kubectl get nodes
     ```
+
 5. Go to `dplsh's` Dockerfile and update the `KUBECTL_VERSION` version to match that of the upgraded AKS version

--- a/docs/runbooks/upgrading-aks.md
+++ b/docs/runbooks/upgrading-aks.md
@@ -81,9 +81,9 @@ for background info on this operation.
    aware that the admin node-pool where harbor runs has a tendency to take a
    long time as the harbor pvcs are slow to migrate to the new node.
 
-Monitor via eg.
+    Monitor via eg.
 
-```shell
-watch -n 5 kubectl get nodes
-```
+    ```shell
+    watch -n 5 kubectl get nodes
+    ```
 5. Go to `dplsh's` Dockerfile and update the `KUBECTL_VERSION` version to match that of the upgraded AKS version


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It add a another step to the upgrade AKS runbook to remind people that the kubectl version should also be updated to match that of the AKS kubernetes version

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
