### PR TITLE
Upgrade AKS and kubectl versions to latest supported 1.27.x.

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -16,7 +16,7 @@ module "environment" {
   # When copying this value, consider leaving it out and falling back to the
   # default of 102400.
   sql_storage_mb          = 409600
-  control_plane_version   = "1.26.10"
+  control_plane_version   = "1.27.9"
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -25,7 +25,7 @@ ARG KREW_VERSION=v0.4.4
 ARG CERT_MANAGER_VERIFIER_VERSION=0.3.0
 
 # The kubectl version can be bumped as we upgrade the cluster minor version.
-ARG KUBECTL_VERSION=v1.26.10
+ARG KUBECTL_VERSION=v1.27.9
 # kubelogin is a client-go credential plugin implementing azure authentication.
 # https://github.com/Azure/kubelogin/releases
 ARG KUBELOGIN_VERSION=v0.0.34


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This upgrades AKS and kubectl to the latest supported 1.27 release.
