### PR TITLE
Task for checking for CAA records in all sites in sites.yaml

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -987,6 +987,16 @@ tasks:
       preconditions:
       - *require_site
 
+    sites:check-caa:
+      desc: |
+        Checks if a site's primary and secondary domains have CAA records registered, and if they do report it.
+        If a site has these records they must be updated to allow zerossl to provision certificates for the site.
+      cmds:
+        - |
+          cat {{.dir_env}}/sites.yaml \
+            | yq '.sites[] | [ .primary-domain ] + .secondary-domains | .[] | select(. | contains("dplplat01.dpl.reload.dk") | not)' \
+            | xargs -I % -n 1 bash -c 'if (( $(dig % CAA | grep issue | wc -l) > 0 )); then echo "There are CAAs for domain %"; fi'
+
     site:lagoon:project:capture-deploy-key:
       # TODO: print a big message if a deploy key is newly captured, so we know to commit changes!
       desc: Gets the deploy key for a particular project from Lagoon and persists it in sites.yaml

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -47,7 +47,8 @@ RUN apk add --no-cache \
   shadow \
   vim \
   yq \
-  openssh
+  openssh \
+  bind-tools
 
 # Add task, a modern Make equivalent.
 RUN curl -sL https://taskfile.dev/install.sh | bash -s -- -b /usr/local/bin ${TASK_VERSION}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Given primary- and secondary-domains in sites.yaml this task checks through all domains to see if any have a CAA record attached. If they do, this is reported.

CAA records present in a DNS record means that we *must* specify the certificate authority allowed to provision certificates for the domain. If any of the libraries have this record we must get them to adjust it prior to going live.

#### Should this be tested by the reviewer and how?

Build and deploy dplsh locally and check that `task sites:check-caa` runs correctly.

#### What are the relevant tickets?

[DDFDRIFT-94](https://reload.atlassian.net/browse/DDFDRIFT-94)

[DDFDRIFT-94]: https://reload.atlassian.net/browse/DDFDRIFT-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ