### PR TITLE
Add task for looping through sites and checking if they have a logo set up

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1019,6 +1019,15 @@ tasks:
       preconditions:
       - *require_site
 
+    sites:report-is-set-up:
+      desc: |
+        Loops through all the sites in sites.yaml and reports whether their logo or logotext has been changed.
+        We use this as an indication for whether the site owners have startet setting up the site.
+      cmds:
+        - |
+          cat {{.dir_env}}/sites.yaml | yq '.sites | keys | .[]' \
+          | xargs -n 1 -I % bash -c 'set -e; if (( $(curl -s https://varnish.main.%.dplplat01.dpl.reload.dk/ | grep "\"header__logo-desktop-link\"" -A 8 | grep "\"logo-fallback\s*\"" -A 4 | grep "Logo title (bold)" | wc -l) > 0 )); then echo "% not yet set up"; fi'
+
     ui-password:
       deps: [cluster:auth]
       desc: Get the password to access a given user interface


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

We use this to get an indication of how many sites have started using the system.

It has the nice added benefit of putting the frontpage in varnish's cache.

#### What are the relevant tickets?

[DDFDRAFT-113](https://reload.atlassian.net/browse/DDFDRIFT-113)