### PR TITLE
New node pools

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -7,9 +7,11 @@ module "environment" {
   # <environment_name>.dpl.reload.dk
   lagoon_domain_base              = "dplplat01.dpl.reload.dk"
   random_seed                     = "LahYegheePhohGeew9Fa"
+  node_pools = {
+    "appdefault": { min: 8, max: 40, vm: "Standard_B4ms" },
+    "admin": { min: 3, max: 6, vm: "Standard_B4ms" }
+  }
   node_pool_system_count          = 2
-  node_pool_app_default_count_min = 8
-  node_pool_app_default_count_max = 40
   # We've increased this quite a bit to test performance. The ideal starting-
   # point seems to be in the range 102400 - 204800 to get enough IOPS to
   # maintain performance during a Drupal site-install.

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -10,7 +10,7 @@ module "environment" {
   node_pools = {
     "appdefault" : { count : 0, vm : "Standard_B4ms" },
     "admin" : { count : 0, vm : "Standard_B4ms", role : "admin" },
-    "app2" : { min : 0, max : 20, vm : "Standard_B8ms", max_pods : 100 },
+    "app2" : { min : 6, max : 15, vm : "Standard_B8ms", max_pods : 100 },
     "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 }
   }
   node_pool_system_count = 2

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,8 +8,8 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "appdefault" : { min : 0, max : 10, vm : "Standard_B4ms" },
-    "admin" : { min : 0, max : 2, vm : "Standard_B4ms", role : "admin" },
+    "appdefault" : { count : 0, vm : "Standard_B4ms" },
+    "admin" : { count : 0, vm : "Standard_B4ms", role : "admin" },
     "app2" : { min : 0, max : 20, vm : "Standard_B8ms", max_pods : 100 },
     "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 }
   }

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "environment" {
   lagoon_domain_base              = "dplplat01.dpl.reload.dk"
   random_seed                     = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "appdefault": { min: 8, max: 40, vm: "Standard_B4ms" },
+    "appdefault": { min: 0, max: 10, vm: "Standard_B4ms" },
     "admin": { min: 0, max: 2, vm: "Standard_B4ms", role: "admin" },
     "app2": { min: 0, max: 20, vm: "Standard_B8ms", max_pods: 100 },
     "admin2": { min: 1, max: 1, vm: "Standard_B8ms", role: "admin", max_pods: 100 }

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -5,22 +5,22 @@ module "environment" {
   environment_name = "dplplat01"
   # This variable current _has_ to match the pattern
   # <environment_name>.dpl.reload.dk
-  lagoon_domain_base              = "dplplat01.dpl.reload.dk"
-  random_seed                     = "LahYegheePhohGeew9Fa"
+  lagoon_domain_base = "dplplat01.dpl.reload.dk"
+  random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "appdefault": { min: 0, max: 10, vm: "Standard_B4ms" },
-    "admin": { min: 0, max: 2, vm: "Standard_B4ms", role: "admin" },
-    "app2": { min: 0, max: 20, vm: "Standard_B8ms", max_pods: 100 },
-    "admin2": { min: 1, max: 1, vm: "Standard_B8ms", role: "admin", max_pods: 100 }
+    "appdefault" : { min : 0, max : 10, vm : "Standard_B4ms" },
+    "admin" : { min : 0, max : 2, vm : "Standard_B4ms", role : "admin" },
+    "app2" : { min : 0, max : 20, vm : "Standard_B8ms", max_pods : 100 },
+    "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 }
   }
-  node_pool_system_count          = 2
+  node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-
   # point seems to be in the range 102400 - 204800 to get enough IOPS to
   # maintain performance during a Drupal site-install.
   # When copying this value, consider leaving it out and falling back to the
   # default of 102400.
-  sql_storage_mb          = 409600
-  control_plane_version   = "1.27.9"
+  sql_storage_mb        = 409600
+  control_plane_version = "1.27.9"
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -9,7 +9,9 @@ module "environment" {
   random_seed                     = "LahYegheePhohGeew9Fa"
   node_pools = {
     "appdefault": { min: 8, max: 40, vm: "Standard_B4ms" },
-    "admin": { min: 3, max: 6, vm: "Standard_B4ms", role: "admin" }
+    "admin": { min: 0, max: 2, vm: "Standard_B4ms", role: "admin" },
+    "app2": { min: 0, max: 20, vm: "Standard_B8ms", max_pods: 100 },
+    "admin2": { min: 1, max: 1, vm: "Standard_B8ms", role: "admin", max_pods: 100 }
   }
   node_pool_system_count          = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -9,7 +9,7 @@ module "environment" {
   random_seed                     = "LahYegheePhohGeew9Fa"
   node_pools = {
     "appdefault": { min: 8, max: 40, vm: "Standard_B4ms" },
-    "admin": { min: 3, max: 6, vm: "Standard_B4ms" }
+    "admin": { min: 3, max: 6, vm: "Standard_B4ms", role: "admin" }
   }
   node_pool_system_count          = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,8 +8,6 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "appdefault" : { count : 0, vm : "Standard_B4ms" },
-    "admin" : { count : 0, vm : "Standard_B4ms", role : "admin" },
     "app2" : { min : 6, max : 15, vm : "Standard_B8ms", max_pods : 100 },
     "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 }
   }

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -87,15 +87,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool" {
   vm_size = each.value.vm
 
   # Enable autoscaling.
-  enable_auto_scaling = true
-  min_count           = each.value.min
-  max_count           = each.value.max
-  #node_count          = each.value.min
-
-  lifecycle {
-    ignore_changes = [
-      # Changed by the autoscaler, so we need to ignore it.
-      node_count
-    ]
-  }
+  enable_auto_scaling = try(each.value.min, try(each.value.max, null)) != null ? true : false
+  min_count           = try(each.value.min, null)
+  max_count           = try(each.value.max, null)
+  node_count          = try(each.value.count, null)
 }

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -19,7 +19,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     vm_size    = var.node_pool_system_vm_sku
 
     # Sync node version with control plane version of k8s
-    orchestrator_version  = var.control_plane_version
+    orchestrator_version = var.control_plane_version
 
     # Attach the cluster to our private network.
     vnet_subnet_id = azurerm_subnet.aks.id

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cluster.id
   vnet_subnet_id        = azurerm_subnet.aks.id
   node_labels = {
-    "noderole.dplplatform" : "application"
+    "noderole.dplplatform" : try(each.value.role, "application")
   }
   zones = [
     "1",

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -18,6 +18,9 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     node_count = var.node_pool_system_count
     vm_size    = var.node_pool_system_vm_sku
 
+    # Sync node version with control plane version of k8s
+    orchestrator_version  = var.control_plane_version
+
     # Attach the cluster to our private network.
     vnet_subnet_id = azurerm_subnet.aks.id
 

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -62,7 +62,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
 # Add a application default nodepool.
 resource "azurerm_kubernetes_cluster_node_pool" "pool" {
-  for_each = var.node_pools
+  for_each              = var.node_pools
   name                  = each.key
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cluster.id
   vnet_subnet_id        = azurerm_subnet.aks.id

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -64,6 +64,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 resource "azurerm_kubernetes_cluster_node_pool" "pool" {
   for_each              = var.node_pools
   name                  = each.key
+  orchestrator_version  = var.control_plane_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cluster.id
   vnet_subnet_id        = azurerm_subnet.aks.id
   node_labels = {

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -34,7 +34,7 @@ variable "location" {
 variable "node_pools" {
   description = "The node pools (other than the system one) used for the cluster"
   default     = {}
-  type        = map
+  type        = map(any)
 }
 
 variable "node_pool_system_count" {

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -37,42 +37,6 @@ variable "node_pools" {
   type        = map
 }
 
-variable "node_pool_admin_count_max" {
-  description = "The maximum number of pods to autoscale the administration nodepool to"
-  default     = 6
-  type        = number
-}
-
-variable "node_pool_admin_count_min" {
-  description = "The minimum number of pods to autoscale the administration nodepool to, also used as the initial count for the nodepool"
-  default     = 3
-  type        = number
-}
-
-variable "node_pool_admin_vm_sku" {
-  description = "The SKU of the virtual machines used for the administration nodepool"
-  default     = "Standard_B4ms"
-  type        = string
-}
-
-variable "node_pool_app_default_count_max" {
-  description = "The maximum number of pods to autoscale the default application nodepool to"
-  default     = 3
-  type        = number
-}
-
-variable "node_pool_app_default_count_min" {
-  description = "The minimum number of pods to autoscale the default application nodepool to, also used as the initial count for the nodepool"
-  default     = 1
-  type        = number
-}
-
-variable "node_pool_app_default_vm_sku" {
-  description = "The SKU of the virtual machines used for the default application nodepool"
-  default     = "Standard_B4ms"
-  type        = string
-}
-
 variable "node_pool_system_count" {
   description = "The number of nodes in the system node-pool"
   default     = 1

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -31,6 +31,12 @@ variable "location" {
   default     = "West Europe"
 }
 
+variable "node_pools" {
+  description = "The node pools (other than the system one) used for the cluster"
+  default     = {}
+  type        = map
+}
+
 variable "node_pool_admin_count_max" {
   description = "The maximum number of pods to autoscale the administration nodepool to"
   default     = 6


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

- ✅ Changes the format for defining node pools to allow dynamically defining more.
- ✅ Creates new app and admin node pools on Standard_B8ms (bigger node machines!)
- ✅ Scales down existing node pools to move load to new node pools
- ✅ Removes old node pools

This branch is up to date with Terraform state and *main is not anymore!*

#### What are the relevant tickets?

[DDFDRIFT-108](https://reload.atlassian.net/browse/DDFDRIFT-108?atlOrigin=eyJpIjoiY2I5ODVkZWNmMGU0NDMwOGJmNDM1ZTNmNDM4OGVlMGQiLCJwIjoiaiJ9)


[DDFDRIFT-108]: https://reload.atlassian.net/browse/DDFDRIFT-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ