### PR TITLE
Aalborg go live

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -45,6 +45,11 @@ sites:
     name: "Aalborg Bibliotekerne"
     description: "The main library site for Aalborg"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE8+vj/1goR+Y42JMD/NbL4PXM4N6DifKbRZjJdyAURp"
+    primary-domain: www.aalborgbibliotekerne.dk
+    secondary-domains:
+      - aalborgbibliotekerne.dk
+      - nginx.main.aalborg.dplplat01.dpl.reload.dk
+      - varnish.main.aalborg.dplplat01.dpl.reload.dk
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Sets primary and secondary domains for Aalborg Bibliotekerne.

This has been executed in the infrastructure.

#### What are the relevant tickets?

[DDFDRIFT-117](https://reload.atlassian.net/browse/DDFDRIFT-117)

[DDFDRIFT-117]: https://reload.atlassian.net/browse/DDFDRIFT-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ