### PR TITLE
Support `autogenerateRoutes` flag on sites, which overrides default autogeneration behavior

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -68,20 +68,27 @@ function renderProfileTemplate {
   local releaseImageName=$4
   # Cron schedule for importing translations
   local importTranslationsCron=$5
+  # Flag for whether or not to autogenerate routes
+  local autogenerateRoutes=${6:-}
   # The primary domain of the site (optional)
-  local primaryDomain=${6:-}
+  local primaryDomain=${7:-}
   # A space-seperated list of secondary domains (optional)
-  local secondaryDomainsString=${7:-}
+  local secondaryDomainsString=${8:-}
 
   PRIMARY_DOMAIN=""
-  ENABLE_ROUTES=""
+
   # This is a little bit terrible. As we're injecting this into a yaml-
   # document we need to maintain the indentation
   local routesIndent="    "
   local singleRouteIndent="${routesIndent}    "
+
+  ENABLE_ROUTES=$(cat << EndOfMessage
+${routesIndent}autogenerateRoutes: ${autogenerateRoutes:-true}
+EndOfMessage
+)
   if [[ -n "${primaryDomain}" ]]; then
-    ENABLE_ROUTES+=$(cat << EndOfMessage
-${routesIndent}autogenerateRoutes: false
+    ENABLE_ROUTES=$(cat << EndOfMessage
+${routesIndent}autogenerateRoutes: ${autogenerateRoutes:-false}
 ${routesIndent}routes:
 ${routesIndent}  - varnish:
 EndOfMessage
@@ -147,8 +154,9 @@ function syncEnvRepo {
   local releaseImageRepository=$4
   local releaseImageName=$5
   local importTranslationsCron=$6
-  local primaryDomain="${7:-}"
-  local secondaryDomains="${8:-}"
+  local autogenerateRoutes="${7:-}"
+  local primaryDomain="${8:-}"
+  local secondaryDomains="${9:-}"
 
   # TODO, preflight checks that verifies this repository looks good to go.
   # makes most sense to do when we're doing more complicated things inside
@@ -181,7 +189,7 @@ function syncEnvRepo {
 
   # Enter the template and rendered it
   cd "${repoName}"
-  renderProfileTemplate "${siteName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${importTranslationsCron}" "${primaryDomain}" "${secondaryDomains}"
+  renderProfileTemplate "${siteName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
 
   # Detect changes
   local changedFiles

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -84,6 +84,16 @@ function getSiteSecondaryDomains {
     return
 }
 
+function getSiteAutogenerateRoutes {
+    local autogenerateRoutes
+    autogenerateRoutes=$(yq eval ".sites.${1}.autogenerateRoutes" "${2}")
+    if [[ "${autogenerateRoutes}" == "null" ]]; then
+        echo ""
+        return
+    fi
+    echo "${autogenerateRoutes}"
+}
+
 function getSiteImportTranslationsCron {
     local importTranslationsCron
     importTranslationsCron=$(yq eval ".sites.${1}.importTranslationsCron" "${2}")
@@ -126,6 +136,7 @@ set +o errexit
 # Get the primary and secondary domains from site.yml.
 primaryDomain=$(getSitePrimaryDomain "${SITE}" "${SITES_CONFIG}")
 secondaryDomains=$(getSiteSecondaryDomains "${SITE}" "${SITES_CONFIG}")
+autogenerateRoutes=$(getSiteAutogenerateRoutes "${SITE}" "${SITES_CONFIG}")
 releaseTag=$(getSiteDplCmsRelease "${SITE}" "${SITES_CONFIG}")
 siteImageRepository=$(getSiteReleaseImageRepository "${SITE}" "${SITES_CONFIG}" || exit 1)
 failOnErr $? "${siteImageRepository}"
@@ -136,7 +147,7 @@ importTranslationsCron=$(getSiteImportTranslationsCron "${SITE}" "${SITES_CONFIG
 set -o errexit
 
 # Synchronise the sites environment repository.
-syncEnvRepo "${SITE}" "${releaseTag}" "${BRANCH}" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}" "${primaryDomain}" "${secondaryDomains}"
+syncEnvRepo "${SITE}" "${releaseTag}" "${BRANCH}" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
 
 if [ "${plan}" = "webmaster" ] && [ "${BRANCH}" = "main" ]; then
     syncEnvRepo "${SITE}" "${releaseTag}" "moduletest" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -20,8 +20,7 @@ sites:
     primary-domain: bibliotest.deranged.dk
     secondary-domains:
       - www.bibliotest.deranged.dk
-      - nginx.main.canary.dplplat01.dpl.reload.dk
-      - varnish.main.canary.dplplat01.dpl.reload.dk
+    autogenerateRoutes: true
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Default is autogenerting UNLESS primary domain is set. Now you can override with custom behavior with the custom flag.

The change has been executed in the platform for canary specifically.

#### Should this be tested by the reviewer and how?

Verify that the [change from applying this change](https://github.com/danishpubliclibraries/env-canary/commit/e69db0f910f4d28392a4bab9677a635d5348cfc6) looks reasonable.

#### What are the relevant tickets?

[DDFDRIFT-120](https://reload.atlassian.net/browse/DDFDRIFT-120?atlOrigin=eyJpIjoiZmJhNTMzZDhmYzFlNDQ0NDllNDA3MzdlZDRiZWM0ZDkiLCJwIjoiaiJ9)

[DDFDRIFT-120]: https://reload.atlassian.net/browse/DDFDRIFT-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ