### PR TITLE
Fix webserver links

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -47,6 +47,7 @@ sites:
     primary-domain: www.aalborgbibliotekerne.dk
     secondary-domains:
       - aalborgbibliotekerne.dk
+    autogenerateRoutes: true
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -47,8 +47,6 @@ sites:
     primary-domain: www.aalborgbibliotekerne.dk
     secondary-domains:
       - aalborgbibliotekerne.dk
-      - nginx.main.aalborg.dplplat01.dpl.reload.dk
-      - varnish.main.aalborg.dplplat01.dpl.reload.dk
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR removes the Varnish and NGINX routes. This should fix a linking issue that Aalborg is having post-databreach

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-127