### PR TITLE
Node pools fewer max pods

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,8 +8,10 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app2" : { min : 6, max : 15, vm : "Standard_B8ms", max_pods : 100 },
-    "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 }
+    "app2" : { min : 0, max : 6, vm : "Standard_B8ms", max_pods : 100 },
+    "app3" : { min : 3, max : 15, vm: "Standard_B8ms", max_pods : 85 },
+    "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 },
+    "admin3" : { min : 0, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,10 +8,8 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app2" : { min : 0, max : 6, vm : "Standard_B8ms", max_pods : 100 },
-    "app3" : { min : 3, max : 15, vm: "Standard_B8ms", max_pods : 85 },
-    "admin2" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 100 },
-    "admin3" : { min : 0, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
+    "app3" : { min : 7, max : 15, vm: "Standard_B8ms", max_pods : 85 },
+    "admin3" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Migrates to node pools with slightly lower max_pods setting. This should give workloads more breathing room to use more resources when needed.

We are limited by Lagoon hardcoding resource requests for pods. At 100 pods it seemed to push the limits of the nodes quite harshly, resulting in slow scheduling and some lowered performance.

The change has been executed in the platform.

#### What are the relevant tickets?

[DDFDRIFT-128](https://reload.atlassian.net/browse/DDFDRIFT-128)

[DDFDRIFT-128]: https://reload.atlassian.net/browse/DDFDRIFT-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ