### PR TITLE
one time password and notify admins

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1160,6 +1160,28 @@ tasks:
             PASSWORD: "{{.PASSWORD}}"
             PROJECT: "{{.PROJECT}}"
 
+
+    site:local-admin:password:create-and-notify:
+      desc: Sets the password for the admin of the selected site
+      deps: [lagoon:cli:config, cluster:auth]
+      dir: "{{.dir_env}}"
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        PASSWORD: "{{.PASSWORD}}"
+        MAIL: "{{.MAIL}}"
+        USERNAME: "{{.USERNAME}}"
+        CONTACTNAME: "{{.CONTACTNAME}}"
+      cmds:
+        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:create '{{.USERNAME}}' --mail='{{.MAIL}}' --password='{{.PASSWORD}}'"
+        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:role:add 'local_administrator' '{{.USERNAME}}'"
+        - task: mail:sent
+          vars:
+            SUBJECT: "Logininformation til jeres nye bibliotekssite"
+            RECIPIENT: "{{.MAIL}}"
+            CONTACTNAME: "{{.CONTACTNAME}}"
+            PASSWORD: "{{.PASSWORD}}"
+            PROJECT: "{{.PROJECT}}"
+
     mail:sent:
       desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
       deps: [cluster:auth]
@@ -1196,7 +1218,7 @@ tasks:
 
                 Loginoplysninger:
 
-                Brugernavn: admin
+                Brugernavn: {{.USERNAME}}
                 Password: {{.PASSWORD}}
 
                 Disse login-oplysninger kan bruges på følgende web-addresse: https://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1150,7 +1150,7 @@ tasks:
       cmds:
         - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:password admin '{{.PASSWORD}}'"
         - for: { var: contacts, as: INDEX}
-          task: mail:sent
+          task: mail:send
           vars:
             SUBJECT: "Logininformation til jeres nye bibliotekssite"
             RECIPIENT:
@@ -1182,7 +1182,7 @@ tasks:
             PASSWORD: "{{.PASSWORD}}"
             PROJECT: "{{.PROJECT}}"
 
-    mail:sent:
+    mail:send:
       desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
       deps: [cluster:auth]
       vars:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
this add a one-time task that allows us quickly send a new admin their credentials

#### Should this be tested by the reviewer and how?
I have already thouroughly tested this. If you have the time to test it can be done by using canary and your own email in the following  command: 
`PROJECT="canary" USERNAME="someUserName" MAIL="your@mail.tld" CONTACTNAME="yourName" PASSWORD="1234Test" task site:local-admin:password:create-and-notify`

#### Any specific requests for how the PR should be reviewed?
Sanity check it

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-37