### PR TITLE
Quicken admin password reset

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1160,67 +1160,6 @@ tasks:
             PASSWORD: "{{.PASSWORD}}"
             PROJECT: "{{.PROJECT}}"
 
-    mail:send:
-      desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
-      deps: [cluster:auth]
-      vars:
-        RECIPIENT: "{{.RECIPIENT}}"
-        SUBJECT: "{{.SUBJECT}}"
-        CONTENT: |
-            CONTENT: |
-                Kære {{.CONTACTNAME}}
-
-                Læs venligst hele mailen før du går i gang. Den indeholder 3 afsnit:
-
-                1. Instruktion om opsætning af brugere
-                2. Loginoplysninger
-                3. En note om certifikatfejl der kan opleves i starten
-
-
-
-                Instruktion om opsætning af brugere:
-
-                Du får hermed adgang til jeres nyt bibliotekssite. Bemærk at medsendte bruger er ens for begge jer, der er kontaktpersoner. Så den første af jer der går ind på sitet skal skifte kodeord og oprette den anden som bruger. Det er vigtigt, at I vælger egne kodeord, så det kun er jer selv der kender det.
-
-                Den brugerkonto der følger med denne mail er af typen Admin, og dermed den brugertype der har flest rettigheder i løsningen (se manualen for beskrivelse af de forskellige brugertyper). Overvej grundigt hvilke brugertyper I giver andre brugere. Af sikkerhedshensyn er det bedre at starte med færre rettigheder for den enkelte, og så "opgradere" dem hvis det bliver nødvendigt.
-
-                Så helt kort:
-
-                - Nulstil kodeord så snart du er logget ind, så det kun er dig der kender det
-
-                - Brug admin-brugeren til at oprette andre brugere, men begræns deres muligheder
-
-                Du kan se mere omkring dette i manualen her:
-                https://www.folkebibliotekernescms.dk/main/startopsaetning/systembrugere/
-
-
-
-                Loginoplysninger:
-
-                Brugernavn: {{.USERNAME}}
-                Password: {{.PASSWORD}}
-
-                Disse login-oplysninger kan bruges på følgende web-addresse: https://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
-
-
-
-                En note om certifikatfejl der kan opleves i starten:
-
-                Vi har desværre nogle fejl med certifikater til test-siderne. Det betyder at I kan opleve fejl i jeres browsere når I forsøger at tilgå jeres nye site.
-
-                Hvis I oplever denne fejl kan I i stedet tilgå en web-addresse der starter med "http", i jeres tilfælde http://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
-
-                Her kan I logge ind og bruge redigeringsmodulerne. Desværre vil login gennem DBC ikke fungere fra denne version af siden.
-
-                Vi arbejder på hurtigst muligt at få sat fungerende certifikater op til alle siderne, og beklager de problemer det måtte skabe for jer!
-
-
-
-                Vi håber I kommer godt igang med vores nye løsning.
-
-                Med venlig hilsen
-                Det Digitale Folkebibliotek
-
 
     site:local-admin:password:create-and-notify:
       desc: Sets the password for the admin of the selected site
@@ -1235,7 +1174,7 @@ tasks:
       cmds:
         - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:create '{{.USERNAME}}' --mail='{{.MAIL}}' --password='{{.PASSWORD}}'"
         - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:role:add 'local_administrator' '{{.USERNAME}}'"
-        - task: mail:sent
+        - task: mail:send
           vars:
             SUBJECT: "Logininformation til jeres nye bibliotekssite"
             RECIPIENT: "{{.MAIL}}"
@@ -1245,11 +1184,10 @@ tasks:
             CONTENT: |
                 Kære {{.CONTACTNAME}}
 
-                Læs venligst hele mailen før du går i gang. Den indeholder 3 afsnit:
+                Læs venligst hele mailen før du går i gang. Den indeholder 2 afsnit:
 
                 1. Instruktion om opsætning af brugere
                 2. Loginoplysninger
-                3. En note om certifikatfejl der kan opleves i starten
 
 
 
@@ -1278,24 +1216,10 @@ tasks:
                 Disse login-oplysninger kan bruges på følgende web-addresse: https://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
 
 
-
-                En note om certifikatfejl der kan opleves i starten:
-
-                Vi har desværre nogle fejl med certifikater til test-siderne. Det betyder at I kan opleve fejl i jeres browsere når I forsøger at tilgå jeres nye site.
-
-                Hvis I oplever denne fejl kan I i stedet tilgå en web-addresse der starter med "http", i jeres tilfælde http://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
-
-                Her kan I logge ind og bruge redigeringsmodulerne. Desværre vil login gennem DBC ikke fungere fra denne version af siden.
-
-                Vi arbejder på hurtigst muligt at få sat fungerende certifikater op til alle siderne, og beklager de problemer det måtte skabe for jer!
-
-
-
                 Vi håber I kommer godt igang med vores nye løsning.
 
                 Med venlig hilsen
                 Det Digitale Folkebibliotek
-
 
     site:local-admin:password:reset:
       desc: Resets the password for the local admin of a site
@@ -1319,17 +1243,16 @@ tasks:
               Du har bedt om at få nulstillet dit password til jeres bibliotekssite.
               Dit nye password er: {{.PASSWORD}}
               Vi anbefaler at du ændrer passwordet til noget du selv kan huske.
-
               Med venlig hilsen
               Det Digitale Folkebibliotek
 
-    mail:sent:
+    mail:send:
       desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
       deps: [cluster:auth]
       vars:
         RECIPIENT: "{{.RECIPIENT}}"
         SUBJECT: "{{.SUBJECT}}"
-        CONTENT: '{{.CONTENT}}'
+        CONTENT: "{{.CONTENT}}"
         CONNECTION_STRING:
           sh: az communication list-key
               --name communication-servicesa5e3

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1295,6 +1295,34 @@ tasks:
 
                 Med venlig hilsen
                 Det Digitale Folkebibliotek
+
+
+    site:local-admin:password:reset:
+      desc: Resets the password for the local admin of a site
+      deps: [cluster:auth, lagoon:cli:config]
+      dir: "{{.dir_env}}"
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        USERNAME: "{{.USERNAME}}"
+        EMAIL: "{{.EMAIL}}"
+        PASSWORD:
+          sh: $RANDOM  | md5sum | head -c 20
+      cmds:
+        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:password {{.USERNAME}} '{{.PASSWORD}}'"
+        - task: mail:sent
+          vars:
+            SUBJECT: "Nulstilling af bibliotekssite password"
+            RECIPIENT: "{{.EMAIL}}"
+            PASSWORD: "{{.PASSWORD}}"
+            CONTENT: |
+              Hej,
+              Du har bedt om at få nulstillet dit password til jeres bibliotekssite.
+              Dit nye password er: {{.PASSWORD}}
+              Vi anbefaler at du ændrer passwordet til noget du selv kan huske.
+
+              Med venlig hilsen
+              Det Digitale Folkebibliotek
+
     mail:sent:
       desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
       deps: [cluster:auth]

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1160,28 +1160,6 @@ tasks:
             PASSWORD: "{{.PASSWORD}}"
             PROJECT: "{{.PROJECT}}"
 
-
-    site:local-admin:password:create-and-notify:
-      desc: Sets the password for the admin of the selected site
-      deps: [lagoon:cli:config, cluster:auth]
-      dir: "{{.dir_env}}"
-      vars:
-        PROJECT: "{{.PROJECT}}"
-        PASSWORD: "{{.PASSWORD}}"
-        MAIL: "{{.MAIL}}"
-        USERNAME: "{{.USERNAME}}"
-        CONTACTNAME: "{{.CONTACTNAME}}"
-      cmds:
-        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:create '{{.USERNAME}}' --mail='{{.MAIL}}' --password='{{.PASSWORD}}'"
-        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:role:add 'local_administrator' '{{.USERNAME}}'"
-        - task: mail:sent
-          vars:
-            SUBJECT: "Logininformation til jeres nye bibliotekssite"
-            RECIPIENT: "{{.MAIL}}"
-            CONTACTNAME: "{{.CONTACTNAME}}"
-            PASSWORD: "{{.PASSWORD}}"
-            PROJECT: "{{.PROJECT}}"
-
     mail:send:
       desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
       deps: [cluster:auth]
@@ -1189,6 +1167,7 @@ tasks:
         RECIPIENT: "{{.RECIPIENT}}"
         SUBJECT: "{{.SUBJECT}}"
         CONTENT: |
+            CONTENT: |
                 Kære {{.CONTACTNAME}}
 
                 Læs venligst hele mailen før du går i gang. Den indeholder 3 afsnit:
@@ -1241,6 +1220,88 @@ tasks:
 
                 Med venlig hilsen
                 Det Digitale Folkebibliotek
+
+
+    site:local-admin:password:create-and-notify:
+      desc: Sets the password for the admin of the selected site
+      deps: [lagoon:cli:config, cluster:auth]
+      dir: "{{.dir_env}}"
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        PASSWORD: "{{.PASSWORD}}"
+        MAIL: "{{.MAIL}}"
+        USERNAME: "{{.USERNAME}}"
+        CONTACTNAME: "{{.CONTACTNAME}}"
+      cmds:
+        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:create '{{.USERNAME}}' --mail='{{.MAIL}}' --password='{{.PASSWORD}}'"
+        - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:role:add 'local_administrator' '{{.USERNAME}}'"
+        - task: mail:sent
+          vars:
+            SUBJECT: "Logininformation til jeres nye bibliotekssite"
+            RECIPIENT: "{{.MAIL}}"
+            CONTACTNAME: "{{.CONTACTNAME}}"
+            PASSWORD: "{{.PASSWORD}}"
+            PROJECT: "{{.PROJECT}}"
+            CONTENT: |
+                Kære {{.CONTACTNAME}}
+
+                Læs venligst hele mailen før du går i gang. Den indeholder 3 afsnit:
+
+                1. Instruktion om opsætning af brugere
+                2. Loginoplysninger
+                3. En note om certifikatfejl der kan opleves i starten
+
+
+
+                Instruktion om opsætning af brugere:
+
+                Du får hermed adgang til jeres nyt bibliotekssite. Bemærk at medsendte bruger er ens for begge jer, der er kontaktpersoner. Så den første af jer der går ind på sitet skal skifte kodeord og oprette den anden som bruger. Det er vigtigt, at I vælger egne kodeord, så det kun er jer selv der kender det.
+
+                Den brugerkonto der følger med denne mail er af typen Admin, og dermed den brugertype der har flest rettigheder i løsningen (se manualen for beskrivelse af de forskellige brugertyper). Overvej grundigt hvilke brugertyper I giver andre brugere. Af sikkerhedshensyn er det bedre at starte med færre rettigheder for den enkelte, og så "opgradere" dem hvis det bliver nødvendigt.
+
+                Så helt kort:
+
+                - Nulstil kodeord så snart du er logget ind, så det kun er dig der kender det
+
+                - Brug admin-brugeren til at oprette andre brugere, men begræns deres muligheder
+
+                Du kan se mere omkring dette i manualen her:
+                https://www.folkebibliotekernescms.dk/main/startopsaetning/systembrugere/
+
+
+
+                Loginoplysninger:
+
+                Brugernavn: {{.USERNAME}}
+                Password: {{.PASSWORD}}
+
+                Disse login-oplysninger kan bruges på følgende web-addresse: https://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
+
+
+
+                En note om certifikatfejl der kan opleves i starten:
+
+                Vi har desværre nogle fejl med certifikater til test-siderne. Det betyder at I kan opleve fejl i jeres browsere når I forsøger at tilgå jeres nye site.
+
+                Hvis I oplever denne fejl kan I i stedet tilgå en web-addresse der starter med "http", i jeres tilfælde http://varnish.main.{{.PROJECT}}.dplplat01.dpl.reload.dk
+
+                Her kan I logge ind og bruge redigeringsmodulerne. Desværre vil login gennem DBC ikke fungere fra denne version af siden.
+
+                Vi arbejder på hurtigst muligt at få sat fungerende certifikater op til alle siderne, og beklager de problemer det måtte skabe for jer!
+
+
+
+                Vi håber I kommer godt igang med vores nye løsning.
+
+                Med venlig hilsen
+                Det Digitale Folkebibliotek
+    mail:sent:
+      desc: Sends an email from DoNotReply@folkebibliotekernescms.dk
+      deps: [cluster:auth]
+      vars:
+        RECIPIENT: "{{.RECIPIENT}}"
+        SUBJECT: "{{.SUBJECT}}"
+        CONTENT: '{{.CONTENT}}'
         CONNECTION_STRING:
           sh: az communication list-key
               --name communication-servicesa5e3

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1233,16 +1233,18 @@ tasks:
           sh: $RANDOM  | md5sum | head -c 20
       cmds:
         - lagoon ssh --project {{.PROJECT}} --environment main -C "drush user:password {{.USERNAME}} '{{.PASSWORD}}'"
-        - task: mail:sent
+        - task: mail:send
           vars:
             SUBJECT: "Nulstilling af bibliotekssite password"
             RECIPIENT: "{{.EMAIL}}"
             PASSWORD: "{{.PASSWORD}}"
             CONTENT: |
               Hej,
+
               Du har bedt om at få nulstillet dit password til jeres bibliotekssite.
               Dit nye password er: {{.PASSWORD}}
               Vi anbefaler at du ændrer passwordet til noget du selv kan huske.
+
               Med venlig hilsen
               Det Digitale Folkebibliotek
 


### PR DESCRIPTION
# This PR is dependent on https://github.com/danskernesdigitalebibliotek/dpl-platform/pull/343

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR does 2 things:
1) It makes the `mail:sent` task easier for other tasks to make use of
2) It makes resetting an admins password way faster

#### Should this be tested by the reviewer and how?
This PR can be tested against the `canary` environment by running the `site:local-admin:password:reset` task and the `    site:local-admin:password:create-and-notify`task. I have tested it thoroughly though, so it's probably not necessary.  

#### Any specific requests for how the PR should be reviewed?
Read it through and check that it makes sense

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-124