### PR TITLE
Release 2024.22.1

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -985,23 +985,23 @@ tasks:
         - task: site:lagoon:project:ensure
           vars:
             SITE: "{{.SITE}}"
-            SKIP: "{{.SKIP_ENSURE_PROJECT}}"
+            SKIP: "{{.SKIP_ENSURE_PROJECT}}{{.SKIP}}"
         - task: site:lagoon:project:capture-deploy-key
           vars:
             SITE: "{{.SITE}}"
-            SKIP: "{{.SKIP_CAPTURE_DEPLOY_KEY}}"
+            SKIP: "{{.SKIP_CAPTURE_DEPLOY_KEY}}{{.SKIP}}"
         - task: env_repos:provision
           vars:
             OPTIONS: -refresh=false
-            SKIP: "{{.SKIP_PROVISION}}"
+            SKIP: "{{.SKIP_PROVISION}}{{.SKIP}}"
         - task: site:lagoon:ensure-first-deployment
           vars:
             SITE: "{{.SITE}}"
-            SKIP: "{{.SKIP_FIRST_DEPLOYMENT}}"
+            SKIP: "{{.SKIP_FIRST_DEPLOYMENT}}{{.SKIP}}"
         - task: site:sync
           vars:
             SITE: "{{.SITE}}"
-            SKIP: "{{.SKIP_REPO_SYNC}}"
+            SKIP: "{{.SKIP_REPO_SYNC}}{{.SKIP}}"
       preconditions:
       - *require_site
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -967,7 +967,7 @@ tasks:
                   exit 0
                 fi
 
-                if [ "$pos_startfrom" -lt "$pos_currentsite" ]; then
+                if [ "$pos_startfrom" -le "$pos_currentsite" ]; then
                   exit 0
                 else
                   echo -n "true"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -940,6 +940,7 @@ tasks:
       vars:
         sites:
           sh: cat {{.dir_env}}/sites.yaml | yq '.sites | keys | .[]'
+        START_FROM_SITE: "{{.START_FROM_SITE}}"
       cmds:
         - task: env_repos:provision
           vars:
@@ -954,6 +955,24 @@ tasks:
             SKIP_PROVISION: "{{.SKIP_PROVISION}}"
             SKIP_FIRST_DEPLOYMENT: "{{.SKIP_FIRST_DEPLOYMENT}}"
             SKIP_REPO_SYNC: "{{.SKIP_REPO_SYNC}}"
+            SKIP:
+              sh: |
+                if [ -z "{{.START_FROM_SITE}}" ]; then
+                  exit 0
+                fi
+                pos_startfrom=$(echo "{{.sites}}" | awk -v item="{{.START_FROM_SITE}}" '{if($0 == item) print NR}')
+                pos_currentsite=$(echo "{{.sites}}" | awk -v item="{{.ITEM}}" '{if($0 == item) print NR}')
+
+                if [ -z "$pos_startfrom" ] || [ -z "$pos_currentsite" ]; then
+                  exit 0
+                fi
+
+                if [ "$pos_startfrom" -lt "$pos_currentsite" ]; then
+                  exit 0
+                else
+                  echo -n "true"
+                  exit 0
+                fi
         - for: { var: sites }
           task: site:autoscaler
           vars:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -512,6 +512,10 @@ sites:
     name: "Vesthimmerlands Biblioteker"
     description: "The library site for Vesthimmerland"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNqMIGZql1EAivzzOPpcq2DmC5tPnA1KvLgtnJBqd1F"
+    primary-domain: "vhbib.dk"
+    secondary-domains:
+      - "www.vhbib.dk"
+    autogenerateRoutes: true
     <<: *default-release-image-source
   viborg:
     name: "Viborg Bibliotekerne"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,15 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.20.2"
-x-patch: &patch-release-image-source
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.19.0"
-x-next: &next-release-image-source
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.22.0"
+  dpl-cms-release: "2024.22.1"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -27,7 +19,7 @@ sites:
     description: "Et site til undervisning i CMSet"
     importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
-    <<: *next-release-image-source
+    <<: *default-release-image-source
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
@@ -48,7 +40,7 @@ sites:
     secondary-domains:
       - aalborgbibliotekerne.dk
     autogenerateRoutes: true
-    <<: *next-release-image-source
+    <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
@@ -90,7 +82,7 @@ sites:
       - nginx.main.billund.dplplat01.dpl.reload.dk
       - varnish.main.billund.dplplat01.dpl.reload.dk
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOsUy+dVkL+KxOYz8zSel7mNkcKrEnqDZPHmsU4sfMv/"
-    <<: *next-release-image-source
+    <<: *default-release-image-source
   bornholm:
     name: "Bornholms Folkebiblioteker"
     description: "The library site for Bornholm"
@@ -225,12 +217,12 @@ sites:
       - nginx.main.herlev.dplplat01.dpl.reload.dk
       - varnish.main.herlev.dplplat01.dpl.reload.dk
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICsQ7blUGjtlSdPU4AV7PR21o2Eqg5IMKTCFX3PV/2Mf"
-    <<: *next-release-image-source
+    <<: *default-release-image-source
   herning:
     name: "Herning Bibliotekerne"
     description: "The main library site for Herning"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4LZWJFrRQQD65WohscqcmX0uqx7/zXFsK/o2tVY/9B"
-    <<: *patch-release-image-source
+    <<: *default-release-image-source
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -39,7 +39,8 @@ sites:
     primary-domain: www.aalborgbibliotekerne.dk
     secondary-domains:
       - aalborgbibliotekerne.dk
-    autogenerateRoutes: true
+      - nginx.main.aalborg.dplplat01.dpl.reload.dk
+      - varnish.main.aalborg.dplplat01.dpl.reload.dk
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
@@ -512,9 +513,9 @@ sites:
     name: "Vesthimmerlands Biblioteker"
     description: "The library site for Vesthimmerland"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNqMIGZql1EAivzzOPpcq2DmC5tPnA1KvLgtnJBqd1F"
-    primary-domain: "vhbib.dk"
+    primary-domain: "www.vhbib.dk"
     secondary-domains:
-      - "www.vhbib.dk"
+      - "vhbib.dk"
     autogenerateRoutes: true
     <<: *default-release-image-source
   viborg:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR releases 2024.22.1 to all sites. 
It also removes the old groups `next`and `patch` and replaces the sites that were assigned them, to the `deafult` group.

#### Should this be tested by the reviewer and how?
No

#### Any specific requests for how the PR should be reviewed?
This should be read through. Please also open up the `sites.yaml` file and check that none of the old groups are assigned to any sites. 

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-134