### PR TITLE
set domains and autoGenerateRoutes for Struer and Faxe

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -128,6 +128,10 @@ sites:
     name: "Faxe Kommunes Bibliotek & Borgerservice"
     description: "The library site for Faxe"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBkdxUoBx0ZAXfMfA0rRUNo2EcUK39fp0M/zKJPOcYx2"
+    primary-domain: "www.faxebibliotek.dk"
+    secondary-domains:
+      - "faxebibliotek.dk"
+    autogenerateRoutes: true
     <<: *default-release-image-source
   fredensborg:
     name: "Fredensborg Bibliotekerne"
@@ -463,6 +467,10 @@ sites:
     name: "Struer Bibliotek"
     description: "The library site for Struer"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAcZDg9Veyvl3u/TGG0lIw6Z8osrEZwd4HhcXvbABAsH"
+    primary-domain: "www.struerbibliotek.dk"
+    secondary-domain:
+      - "struerbibliotek.dk"
+    autogenerateRoutes: true
     <<: *default-release-image-source
   sydslesvig:
     name: "Dansk Centralbibliotek for Sydslesvig e.V."

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -468,7 +468,7 @@ sites:
     description: "The library site for Struer"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAcZDg9Veyvl3u/TGG0lIw6Z8osrEZwd4HhcXvbABAsH"
     primary-domain: "www.struerbibliotek.dk"
-    secondary-domain:
+    secondary-domains:
       - "struerbibliotek.dk"
     autogenerateRoutes: true
     <<: *default-release-image-source


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR does what it says on the tin

#### Should this be tested by the reviewer and how?
This should be carefully read through. Please go to the domains for each site, and verify that the primary is infact the primary domain and that the secondary domain redirects to the primary domain

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-136