### PR TITLE
Autogenerate redirect routes

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -77,18 +77,31 @@ function renderProfileTemplate {
 
   PRIMARY_DOMAIN=""
 
+  if [[ "${autogenerateRoutes}" == "redirect" ]]; then
+    autogenerateRoutes="false"
+    secondaryDomainsString="${secondaryDomainsString} varnish.main.${siteName}.dplplat01.dpl.reload.dk nginx.main.${siteName}.dplplat01.dpl.reload.dk"
+  fi
+
+  if [[ -z "${autogenerateRoutes}" && -n "${primaryDomain}" ]]; then
+    autogenerateRoutes="false"
+  fi
+
+  if [[ -z "${autogenerateRoutes}" ]]; then
+    autogenerateRoutes="true"
+  fi
+
   # This is a little bit terrible. As we're injecting this into a yaml-
   # document we need to maintain the indentation
   local routesIndent="    "
   local singleRouteIndent="${routesIndent}    "
 
   ENABLE_ROUTES=$(cat << EndOfMessage
-${routesIndent}autogenerateRoutes: ${autogenerateRoutes:-true}
+${routesIndent}autogenerateRoutes: ${autogenerateRoutes}
 EndOfMessage
 )
   if [[ -n "${primaryDomain}" ]]; then
     ENABLE_ROUTES=$(cat << EndOfMessage
-${routesIndent}autogenerateRoutes: ${autogenerateRoutes:-false}
+${routesIndent}autogenerateRoutes: ${autogenerateRoutes}
 ${routesIndent}routes:
 ${routesIndent}  - varnish:
 EndOfMessage

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -498,7 +498,7 @@ sites:
     primary-domain: "www.struerbibliotek.dk"
     secondary-domains:
       - "struerbibliotek.dk"
-    autogenerateRoutes: true
+    autogenerateRoutes: "redirect"
     <<: *default-release-image-source
   sydslesvig:
     name: "Dansk Centralbibliotek for Sydslesvig e.V."
@@ -553,7 +553,7 @@ sites:
     primary-domain: "www.vhbib.dk"
     secondary-domains:
       - "vhbib.dk"
-    autogenerateRoutes: true
+    autogenerateRoutes: "redirect"
     <<: *default-release-image-source
   viborg:
     name: "Viborg Bibliotekerne"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -41,8 +41,7 @@ sites:
     primary-domain: www.aalborgbibliotekerne.dk
     secondary-domains:
       - aalborgbibliotekerne.dk
-      - nginx.main.aalborg.dplplat01.dpl.reload.dk
-      - varnish.main.aalborg.dplplat01.dpl.reload.dk
+    autogenerateRoutes: "redirect"
     plan: webmaster
     <<: *default-release-image-source
   aarhus:
@@ -88,8 +87,7 @@ sites:
       - www.billundbib.dk
       - billundbibliotek.dk
       - www.billundbibliotek.dk
-      - nginx.main.billund.dplplat01.dpl.reload.dk
-      - varnish.main.billund.dplplat01.dpl.reload.dk
+    autogenerateRoutes: "redirect"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOsUy+dVkL+KxOYz8zSel7mNkcKrEnqDZPHmsU4sfMv/"
     <<: *default-release-image-source
   bornholm:
@@ -232,8 +230,7 @@ sites:
     primary-domain: www.herlevbibliotek.dk
     secondary-domains:
       - herlevbibliotek.dk
-      - nginx.main.herlev.dplplat01.dpl.reload.dk
-      - varnish.main.herlev.dplplat01.dpl.reload.dk
+    autogenerateRoutes: "redirect"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICsQ7blUGjtlSdPU4AV7PR21o2Eqg5IMKTCFX3PV/2Mf"
     <<: *default-release-image-source
   herning:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Allows a new value for `autogenerateRoutes` called `"redirect"` which indicates that we want traffic to the auto-generated routes (nginx.main.<site>... and varnish.main.<site>...) to be redirected to the primary domain set on the site.

Tested and executed on canary, c.f. https://nginx.main.canary.dplplat01.dpl.reload.dk/

Tested the equivalence with previous approach for aalborg, c.f. changes (only the order has changed): https://github.com/danishpubliclibraries/env-aalborg/commit/e883478b78216710c46c1f78b5bc5cae94c4d50a

The move of launched domains `autogenerateRoutes: {true->"redirect"}` has **not** been executed.

#### Should this be tested by the reviewer and how?

Read through and validate that this approach makes sense. Test the executed changes mentioned above.

#### What are the relevant tickets?

[DDFDRIFT-138: Få domæner sat op for Struer og Faxe så de kan gå live når de vil](https://reload.atlassian.net/browse/DDFDRIFT-138)