### PR TITLE
Local admin to admin task

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1301,5 +1301,15 @@ tasks:
           task: site:local-admin:admin:execute
           vars:
             ADMINID: "{{.ITEM}}"
+
+    site:local-admin:admin:execute:
+      desc: Switches the local admin user to an admin user
+      dir: "{{.dir_env}}"
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        ENVIRONMENT: "{{.ENVIRONMENT}}"
+        ADMIN:
+          sh: lagoon ssh -p canary -e main -C "drush uinf --field='name' --uid={{.ADMINID}}"
       cmds:
-        - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.USERNAME}}'; drush user:role:remove 'local_administrator' '{{.USERNAME}}'"
+        - echo {{.ADMINID}}
+        - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.ADMIN}}'"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1309,8 +1309,7 @@ tasks:
         PROJECT: "{{.PROJECT}}"
         ENVIRONMENT: "{{.ENVIRONMENT}}"
         ADMIN:
-          sh: lagoon ssh -p canary -e main -C "drush uinf --field='name' --uid={{.ADMINID}}"
+          sh: lagoon ssh -p canary -e main -C "drush uinf --field='name' --uid='{{.ADMINID}}'"
       cmds:
-        - echo {{.ADMINID}}
         - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.ADMIN}}'"
         - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:remove 'local_administrator' '{{.ADMIN}}'"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1294,6 +1294,12 @@ tasks:
       vars:
         PROJECT: "{{.PROJECT}}"
         ENVIRONMENT: "{{.ENVIRONMENT}}"
-        USERNAME: "{{.USERNAME}}"
+        ADMINS:
+          sh: lagoon ssh -p canary -e main -C "drush sqlq 'SELECT GROUP_CONCAT(entity_id) FROM user__roles WHERE roles_target_id=\"administrator\"'" | sed 's/,/\n/g'
+      cmds:
+        - for: { var: ADMINS, as: ITEM }
+          task: site:local-admin:admin:execute
+          vars:
+            ADMINID: "{{.ITEM}}"
       cmds:
         - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.USERNAME}}'; drush user:role:remove 'local_administrator' '{{.USERNAME}}'"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1313,3 +1313,4 @@ tasks:
       cmds:
         - echo {{.ADMINID}}
         - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.ADMIN}}'"
+        - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:remove 'local_administrator' '{{.ADMIN}}'"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1286,3 +1286,14 @@ tasks:
             PROJECT: "{{.ITEM}}"
             PASSWORD:
               sh: $RANDOM  | md5sum | head -c 20
+
+    site:local-admin:admin:
+      desc: Switches the local admin user to an admin user
+      deps: [cluster:auth, lagoon:cli:config]
+      dir: "{{.dir_env}}"
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        ENVIRONMENT: "{{.ENVIRONMENT}}"
+        USERNAME: "{{.USERNAME}}"
+      cmds:
+        - lagoon ssh --project {{.PROJECT}} --environment {{.ENVIRONMENT}} -C "drush user:role:add 'administrator' '{{.USERNAME}}'; drush user:role:remove 'local_administrator' '{{.USERNAME}}'"

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1295,7 +1295,7 @@ tasks:
         PROJECT: "{{.PROJECT}}"
         ENVIRONMENT: "{{.ENVIRONMENT}}"
         ADMINS:
-          sh: lagoon ssh -p canary -e main -C "drush sqlq 'SELECT GROUP_CONCAT(entity_id) FROM user__roles WHERE roles_target_id=\"administrator\"'" | sed 's/,/\n/g'
+          sh: lagoon ssh -p canary -e main -C "drush sqlq 'SELECT GROUP_CONCAT(entity_id) FROM user__roles WHERE roles_target_id=\"local_administrator\"'" | sed 's/,/\n/g'
       cmds:
         - for: { var: ADMINS, as: ITEM }
           task: site:local-admin:admin:execute


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR makes it really easy to change `local_administrators` of an environment to `administrators` thereby enabling them to upload modules to their site

#### Should this be tested by the reviewer and how?
This should be tested by adding a `local_administrator` to canary og cms-school and the running the task and seeing that they switched roles to `administrator`

#### Any specific requests for how the PR should be reviewed?
Read it through and test it

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-136