### PR TITLE
Webmaster pilot sites

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -46,13 +46,13 @@ sites:
       - aalborgbibliotekerne.dk
       - nginx.main.aalborg.dplplat01.dpl.reload.dk
       - varnish.main.aalborg.dplplat01.dpl.reload.dk
-    plan: webmaster
+    # plan: webmaster
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFL+uMeEfsaHEzbNxOmBB8dX32OLo63CTomG8VZvuiN2"
-    plan: webmaster
+    # plan: webmaster
     <<: *default-release-image-source
   aero:
     name: "Ærø Folkebibliotek"
@@ -139,7 +139,7 @@ sites:
     secondary-domains:
       - "faxebibliotek.dk"
     autogenerateRoutes: true
-    plan: webmaster
+    # plan: webmaster
     <<: *default-release-image-source
   fredensborg:
     name: "Fredensborg Bibliotekerne"
@@ -235,7 +235,7 @@ sites:
     name: "Herning Bibliotekerne"
     description: "The main library site for Herning"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4LZWJFrRQQD65WohscqcmX0uqx7/zXFsK/o2tVY/9B"
-    plan: webmaster
+    # plan: webmaster
     <<: *default-release-image-source
   hillerod:
     name: "Hillerød Bibliotekerne"
@@ -310,7 +310,7 @@ sites:
     #   - www.bibliotek.kk.dk
     #   - nginx.main.kobenhavn.dplplat01.dpl.reload.dk
     #   - varnish.main.kobenhavn.dplplat01.dpl.reload.dk
-    plan: webmaster
+    # plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
     <<: *default-release-image-source
   koge:
@@ -501,7 +501,7 @@ sites:
     name: "Tårnby Kommunebiblioteker"
     description: "The library site for Tårnby"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF0F5bqQwdmAdMcDHVT8xxK0tOEGZYp21WIZ1zydr28O"
-    plan: webmaster
+    # plan: webmaster
     <<: *default-release-image-source
   thisted:
     name: "Biblioteket i Thy"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -45,11 +45,13 @@ sites:
       - aalborgbibliotekerne.dk
       - nginx.main.aalborg.dplplat01.dpl.reload.dk
       - varnish.main.aalborg.dplplat01.dpl.reload.dk
+    plan: webmaster
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFL+uMeEfsaHEzbNxOmBB8dX32OLo63CTomG8VZvuiN2"
+    plan: webmaster
     <<: *default-release-image-source
   aero:
     name: "Ærø Folkebibliotek"
@@ -136,6 +138,7 @@ sites:
     secondary-domains:
       - "faxebibliotek.dk"
     autogenerateRoutes: true
+    plan: webmaster
     <<: *default-release-image-source
   fredensborg:
     name: "Fredensborg Bibliotekerne"
@@ -231,6 +234,7 @@ sites:
     name: "Herning Bibliotekerne"
     description: "The main library site for Herning"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4LZWJFrRQQD65WohscqcmX0uqx7/zXFsK/o2tVY/9B"
+    plan: webmaster
     <<: *default-release-image-source
   hillerod:
     name: "Hillerød Bibliotekerne"
@@ -305,6 +309,7 @@ sites:
     #   - www.bibliotek.kk.dk
     #   - nginx.main.kobenhavn.dplplat01.dpl.reload.dk
     #   - varnish.main.kobenhavn.dplplat01.dpl.reload.dk
+    plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
     <<: *default-release-image-source
   koge:
@@ -495,6 +500,7 @@ sites:
     name: "Tårnby Kommunebiblioteker"
     description: "The library site for Tårnby"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF0F5bqQwdmAdMcDHVT8xxK0tOEGZYp21WIZ1zydr28O"
+    plan: webmaster
     <<: *default-release-image-source
   thisted:
     name: "Biblioteket i Thy"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -17,6 +17,7 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.23.0"
+    plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -46,13 +46,13 @@ sites:
       - aalborgbibliotekerne.dk
       - nginx.main.aalborg.dplplat01.dpl.reload.dk
       - varnish.main.aalborg.dplplat01.dpl.reload.dk
-    # plan: webmaster
+    plan: webmaster
     <<: *default-release-image-source
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFL+uMeEfsaHEzbNxOmBB8dX32OLo63CTomG8VZvuiN2"
-    # plan: webmaster
+    plan: webmaster
     <<: *default-release-image-source
   aero:
     name: "Ærø Folkebibliotek"
@@ -139,7 +139,7 @@ sites:
     secondary-domains:
       - "faxebibliotek.dk"
     autogenerateRoutes: true
-    # plan: webmaster
+    plan: webmaster
     <<: *default-release-image-source
   fredensborg:
     name: "Fredensborg Bibliotekerne"
@@ -235,7 +235,7 @@ sites:
     name: "Herning Bibliotekerne"
     description: "The main library site for Herning"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4LZWJFrRQQD65WohscqcmX0uqx7/zXFsK/o2tVY/9B"
-    # plan: webmaster
+    plan: webmaster
     <<: *default-release-image-source
   hillerod:
     name: "Hillerød Bibliotekerne"
@@ -312,6 +312,7 @@ sites:
     #   - varnish.main.kobenhavn.dplplat01.dpl.reload.dk
     # plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
+    plan: webmaster
     <<: *default-release-image-source
   koge:
     name: "KøgeBibliotekerne"
@@ -501,7 +502,7 @@ sites:
     name: "Tårnby Kommunebiblioteker"
     description: "The library site for Tårnby"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF0F5bqQwdmAdMcDHVT8xxK0tOEGZYp21WIZ1zydr28O"
-    # plan: webmaster
+    plan: webmaster
     <<: *default-release-image-source
   thisted:
     name: "Biblioteket i Thy"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR assigns København, Herning, Faxe, Tårnby, Århus and Aalborg to the webmaster plan. When run, this will result in them having `moduletest` environments. 

**This has only been run on canary and not the actual libraries** 

#### Should this be tested by the reviewer and how?
This should be read throuh, ensuring that the libraries mentioned above has the property `plan`set to `webmaster`

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-137