### PR TITLE
ensure that the .lagoon.yaml file on moduletest is valid

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -97,8 +97,8 @@ EndOfMessage
   fi
 
   # Only render secondary domains if we have a primary domain.
+  SECONDARY_DOMAINS=""
   if [[ -n "${primaryDomain}" && -n "${secondaryDomainsString}" ]]; then
-    SECONDARY_DOMAINS=""
     IFS=' '
     for secondaryDomain in ${secondaryDomainsString}; do
       SECONDARY_DOMAINS+=$(cat << EndOfMessage

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -150,5 +150,5 @@ set -o errexit
 syncEnvRepo "${SITE}" "${releaseTag}" "${BRANCH}" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
 
 if [ "${plan}" = "webmaster" ] && [ "${BRANCH}" = "main" ]; then
-    syncEnvRepo "${SITE}" "${releaseTag}" "moduletest" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}"
+    syncEnvRepo "${SITE}" "${releaseTag}" "moduletest" "${siteImageRepository}" "${siteReleaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
 fi


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR fixes the moduletest environment by ensuring that the .lagoon.yaml file is valid. This is done by having it match the one on main. 

#### Should this be tested by the reviewer and how?
Read it through and make sure that it makes sense. 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-137