### PR TITLE
up the minimum number of nodes to 9

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { min : 7, max : 15, vm: "Standard_B8ms", max_pods : 85 },
+    "app3" : { min : 9, max : 15, vm: "Standard_B8ms", max_pods : 85 },
     "admin3" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
   }
   node_pool_system_count = 2


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR is related to the build and deploy errors we are encountering. The theory right now is that, because Lagoon has decided on `ressrouce_req` and set that to low, the workloads are requesting way more resources than available on the node. Therefore we can try to have more nodes for Kubernetes to spread the workload on. 

#### Should this be tested by the reviewer and how?
Just read it through and see that the `min` has been set to 9

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-148