### PR TITLE
Version metrics endpoint + JSON logs from nginx

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -60,20 +60,22 @@ function getCleanWorkspacePath {
 function renderProfileTemplate {
   # Name of the site
   local siteName=$1
+  # Env of the site
+  local siteEnv=$2
   # Which dpl-cms release to use.
-  local releaseTag=$2
+  local releaseTag=$3
   # Image registry to pull the release from
-  local releaseImageRepository=$3
+  local releaseImageRepository=$4
   # Name of the container-image that contains the built release
-  local releaseImageName=$4
+  local releaseImageName=$5
   # Cron schedule for importing translations
-  local importTranslationsCron=$5
+  local importTranslationsCron=$6
   # Flag for whether or not to autogenerate routes
-  local autogenerateRoutes=${6:-}
+  local autogenerateRoutes=${7:-}
   # The primary domain of the site (optional)
-  local primaryDomain=${7:-}
+  local primaryDomain=${8:-}
   # A space-seperated list of secondary domains (optional)
-  local secondaryDomainsString=${8:-}
+  local secondaryDomainsString=${9:-}
 
   PRIMARY_DOMAIN=""
 
@@ -119,6 +121,7 @@ EndOfMessage
   export RELEASE_TAG="${releaseTag}"
   export ENABLE_ROUTES
   export LAGOON_PROJECT_NAME="${siteName}"
+  export LAGOON_ENVIRONMENT="${siteEnv}"
   export LAGOON_IMAGES_RELEASE_TAG
   export PRIMARY_DOMAIN
   export SECONDARY_DOMAINS
@@ -128,7 +131,7 @@ EndOfMessage
   # Tell envsubst which variables to replace. This allows other variables to
   # remain untouched.
   # shellcheck disable=SC2016
-  local variablesToSubst='$RELEASE_IMAGE_REPOSITORY $RELEASE_IMAGE_NAME $RELEASE_TAG $ENABLE_ROUTES $LAGOON_IMAGES_RELEASE_TAG $LAGOON_PROJECT_NAME $PRIMARY_DOMAIN $SECONDARY_DOMAINS $IMPORT_TRANSLATIONS_CRON'
+  local variablesToSubst='$RELEASE_IMAGE_REPOSITORY $RELEASE_IMAGE_NAME $RELEASE_TAG $ENABLE_ROUTES $LAGOON_IMAGES_RELEASE_TAG $LAGOON_PROJECT_NAME $LAGOON_ENVIRONMENT $PRIMARY_DOMAIN $SECONDARY_DOMAINS $IMPORT_TRANSLATIONS_CRON'
 
   # Loop through the files we know to contain variables that needs replacing.
   local templateFiles=(
@@ -136,6 +139,8 @@ EndOfMessage
     "lagoon/cli.dockerfile"
     "lagoon/nginx.dockerfile"
     "lagoon/php.dockerfile"
+    "lagoon/conf/nginx/metrics/version.txt"
+    "lagoon/conf/nginx/metrics/version.json"
     "README.md"
   )
   for templateFile in "${templateFiles[@]}"
@@ -189,7 +194,7 @@ function syncEnvRepo {
 
   # Enter the template and rendered it
   cd "${repoName}"
-  renderProfileTemplate "${siteName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
+  renderProfileTemplate "${siteName}" "${branchName}" "${releaseTag}" "${releaseImageRepository}" "${releaseImageName}" "${importTranslationsCron}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}"
 
   # Detect changes
   local changedFiles

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/http_log_format.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/http_log_format.conf
@@ -1,0 +1,2 @@
+log_format upstreaminfo '{"time": "$time_iso8601", "remote_addr": "$proxy_add_x_forwarded_for", "x-forward-for": "$proxy_add_x_forwarded_for", "bytes_sent": $bytes_sent, "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol", "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer", "http_user_agent": "$http_user_agent" }';
+access_log /dev/stdout upstreaminfo;

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/metrics/version.json
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/metrics/version.json
@@ -1,0 +1,9 @@
+{
+    "site": "${LAGOON_PROJECT_NAME}",
+    "env": "${LAGOON_ENVIRONMENT}",
+    "imageVersion": {
+        "repository": "${RELEASE_IMAGE_REPOSITORY}",
+        "image": "${RELEASE_IMAGE_NAME}",
+        "tag": "${RELEASE_TAG}"
+    }
+}

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/metrics/version.txt
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/metrics/version.txt
@@ -1,0 +1,1 @@
+site_image_version{site="${LAGOON_PROJECT_NAME}" env="${LAGOON_ENVIRONMENT}" repository="${RELEASE_IMAGE_REPOSITORY}" image="${RELEASE_IMAGE_NAME}" tag="${RELEASE_TAG}"}

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_serve_metrics.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_serve_metrics.conf
@@ -1,0 +1,7 @@
+  location /_metrics/ {
+    set $metrics_file_extension ".txt";
+    if ($http_accept ~ "application/json") {
+      set $metrics_file_extension ".json";
+    }
+    try_files $uri$metrics_file_extension $uri @drupal;
+  }

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
@@ -21,5 +21,9 @@ RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_modules_local.
 COPY lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 
+COPY lagoon/conf/nginx/metrics /app/web/_metrics
+COPY lagoon/conf/nginx/server_append_drupal_serve_metrics.conf /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf
+RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf
+
 # Define where the Drupal Root is located
 ENV WEBROOT=web

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
@@ -25,5 +25,8 @@ COPY lagoon/conf/nginx/metrics /app/web/_metrics
 COPY lagoon/conf/nginx/server_append_drupal_serve_metrics.conf /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf
 
+COPY lagoon/conf/nginx/http_log_format.conf /etc/nginx/conf.d/http_log_format.conf
+RUN fix-permissions /etc/nginx/conf.d/http_log_format.conf
+
 # Define where the Drupal Root is located
 ENV WEBROOT=web


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

- Adds /_metrics/version{.json,.txt,} endpoint to all sites which exposes information about the image running in this instance.
- Sets up JSON logging from the nginx instance consistent with the format we use for the ingress

These changes will be used for Grafana dashboards.

The changes have been executed on canary.

#### Should this be tested by the reviewer and how?

Review logs from canary using `kubectl logs` and check the metrics endpoint on https://bibliotest.deranged.dk/_metrics/version - does it make sense?

#### What are the relevant tickets?

[DDFDRIFT-150](https://reload.atlassian.net/browse/DDFDRIFT-150)
[DDFDRIFT-151](https://reload.atlassian.net/browse/DDFDRIFT-151)
[DDFDRIFT-152](https://reload.atlassian.net/browse/DDFDRIFT-152)

[DDFDRIFT-150]: https://reload.atlassian.net/browse/DDFDRIFT-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFDRIFT-151]: https://reload.atlassian.net/browse/DDFDRIFT-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFDRIFT-152]: https://reload.atlassian.net/browse/DDFDRIFT-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ