### PR TITLE
Fail-fast in post-rollout

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -10,6 +10,7 @@ tasks:
     - run:
         name: If drupal is not installed
         command: |
+            set -e
             if tables=$(drush sqlq "show tables like 'node';") && [ -z "$tables" ]; then
                 drush si --existing-config -y
             fi
@@ -18,6 +19,7 @@ tasks:
     - run:
         name: drush deploy
         command: |
+            set -e
             if [[ -f config/sync/system.site.yml ]]; then
                 echo "Config detected, doing a drush deploy"
                 drush deploy
@@ -37,6 +39,7 @@ tasks:
         # it will be gone.
         name: Create module upload directory in public files
         command: |
+            set -e
             if [[ ! -d "web/sites/default/files/modules_local" ]]; then
                 echo "Creating directory for module uploads"
                 mkdir web/sites/default/files/modules_local
@@ -45,6 +48,7 @@ tasks:
     - run:
         name: Import translations
         command: |
+            set -e;
             drush locale-check
             drush locale-update
         service: cli


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Ensures that deploy-time post-rollout tasks fail loudly. Currently they fail silently, and deployment continues, and we may miss them.

Based on https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1113

I ran a diff between env-canary's .lagoon.yml and dpl-cms' version of the same time, and made these changes. The remaining changes seem intentional.

Executed on canary.

#### Should this be tested by the reviewer and how?

See the changes made to env-canary here: https://github.com/danishpubliclibraries/env-canary/compare/9fe6e48c65275b8bc737db7caff46d2860878836...f51ae445ee0e0d513016275c38e9095492749ef1

Do they seem reasonable?

#### What are the relevant tickets?

[DDFDRIFT-111](https://reload.atlassian.net/browse/DDFDRIFT-111)


[DDFDRIFT-111]: https://reload.atlassian.net/browse/DDFDRIFT-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ