### PR TITLE
Add task to show the latest backup for each site

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1066,6 +1066,18 @@ tasks:
             | grep -v ": 0 matches"
           echo "done"
 
+    sites:latest-backup:
+      desc: Show the timestamp for the last successful backup for each site
+      vars:
+        SITES:
+          sh: lagoon list projects --output-json | jq -r ".data[].projectname"
+      cmds:
+        - for: { var: SITES }
+          cmd: |
+            DATE=$(lagoon list backups -p {{.ITEM}} -e main --output-json | jq -r '.data[0].created')
+            echo "{{.ITEM}}: ${DATE}"
+          silent: true
+
     site:lagoon:project:capture-deploy-key:
       # TODO: print a big message if a deploy key is newly captured, so we know to commit changes!
       desc: Gets the deploy key for a particular project from Lagoon and persists it in sites.yaml


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Currently we have no good way of identifying failing backups. Our best way to check that they are running for all sites is to check when the last succesfull backup was run.

To help in this process we add a new task which retrieves this from each site in Lagoon and prints it.

Use silent to avoid printing the shell command for each site. This makes the output more compact.

#### Should this be tested by the reviewer and how?

Try running the task for yourself.