### PR TITLE
Switch to new nodepool

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -78,7 +78,7 @@ tasks:
         Use Terraform to provision the infrastructure for an environment.
       dir: "{{.dir_infra}}"
       cmds:
-        - terraform apply
+        - terraform apply {{.OPTIONS}}
 
     infra:keyvault:secret:set:
       deps: [_req_env, _infra:terraform:init]

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { count: 9, vm: "Standard_B8ms", max_pods : 85 },
+    "app3" : { count: 7, vm: "Standard_B8ms", max_pods : 85 },
     "admin3" : { count: 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
     "app4" : { min : 4, max : 15, vm: "Standard_E4s_v3", max_pods : 70 },
     "admin4" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 70 },

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -9,7 +9,7 @@ module "environment" {
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
     "app4" : { min : 7, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },
-    "admin5" : { count : 1, vm : "Standard_E4s_v3", max_pods : 70 },
+    "admin6": { count : 1, vm : "Standard_E4s_v3", role: "admin", max_pods : 60, },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,9 +8,10 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { min : 11, max : 15, vm: "Standard_B8ms", max_pods : 85 },
+    "app3" : { count: 10, vm: "Standard_B8ms", max_pods : 85 },
+    "admin3" : { count: 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
     "app4" : { min : 4, max : 15, vm: "Standard_E4s_v3", max_pods : 70 },
-    "admin3" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
+    "admin4" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 70 },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -9,7 +9,7 @@ module "environment" {
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
     "app4" : { min : 7, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },
-    "admin6": { count : 1, vm : "Standard_E4s_v3", role: "admin", max_pods : 60, },
+    "admin6": { count : 1, vm : "Standard_E4s_v3", role : "admin", max_pods : 60, },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,7 +8,7 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { count: 10, vm: "Standard_B8ms", max_pods : 85 },
+    "app3" : { count: 9, vm: "Standard_B8ms", max_pods : 85 },
     "admin3" : { count: 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
     "app4" : { min : 4, max : 15, vm: "Standard_E4s_v3", max_pods : 70 },
     "admin4" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 70 },

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,7 +8,6 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { count: 0, vm: "Standard_B8ms", max_pods : 85 },
     "app4" : { min : 7, max : 20, vm: "Standard_E4s_v3", max_pods : 70 },
     "admin5" : { count: 1, vm: "Standard_E4s_v3", max_pods: 70 },
   }

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,8 +8,8 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app4" : { min : 7, max : 20, vm: "Standard_E4s_v3", max_pods : 70 },
-    "admin5" : { count: 1, vm: "Standard_E4s_v3", max_pods: 70 },
+    "app4" : { min : 7, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },
+    "admin5" : { count : 1, vm : "Standard_E4s_v3", max_pods : 70 },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,10 +8,9 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { count: 8, vm: "Standard_B8ms", max_pods : 85 },
-    "admin3" : { count: 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
-    "app4" : { min : 4, max : 4, vm: "Standard_E4s_v3", max_pods : 70 },
-    "admin4" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 70 },
+    "app3" : { count: 0, vm: "Standard_B8ms", max_pods : 85 },
+    "app4" : { min : 7, max : 20, vm: "Standard_E4s_v3", max_pods : 70 },
+    "admin5" : { count: 1, vm: "Standard_E4s_v3", max_pods: 70 },
   }
   node_pool_system_count = 2
   # We've increased this quite a bit to test performance. The ideal starting-

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,9 +8,9 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app3" : { count: 7, vm: "Standard_B8ms", max_pods : 85 },
+    "app3" : { count: 8, vm: "Standard_B8ms", max_pods : 85 },
     "admin3" : { count: 1, vm : "Standard_B8ms", role : "admin", max_pods : 85 },
-    "app4" : { min : 4, max : 15, vm: "Standard_E4s_v3", max_pods : 70 },
+    "app4" : { min : 4, max : 4, vm: "Standard_E4s_v3", max_pods : 70 },
     "admin4" : { min : 1, max : 1, vm : "Standard_B8ms", role : "admin", max_pods : 70 },
   }
   node_pool_system_count = 2

--- a/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/aks.tf
@@ -1,6 +1,7 @@
 # Setup a single cluster in a single availabillity zone.
 resource "azurerm_kubernetes_cluster" "cluster" {
   name                = "aks-${var.environment_name}-01"
+  sku_tier            = "Standard"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   dns_prefix          = var.environment_name

--- a/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
+++ b/infrastructure/terraform/modules/dpl-platform-environment/variables.tf
@@ -57,7 +57,7 @@ variable "random_seed" {
 variable "sql_sku" {
   description = "The SKU used for MariaDB"
   type        = string
-  default     = "GP_Gen5_2"
+  default     = "GP_Gen5_4"
 }
 
 variable "sql_version" {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Slowly switches to E-series boxes for our workloads. They are high in memory and lower in CPU, which fits our usage profile better for the money.

Also improved SLA for AKS cluster and database settings.

Now fully switched over. Has been executed.

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
