### PR TITLE
Refactor incomplete deployments task

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1046,10 +1046,18 @@ tasks:
         Gets the latest deployment for each production environment and prints its status if it is *not* complete.
       cmds:
         - |
-          lagoon list projects --output-json \
-            | jq -r '.data[].projectname'  \
-            | while read -r projectname; do echo "$projectname: $(lagoon list deployments -e main -p $projectname --output-json | jq '.data[0].status')"; done \
-            | grep -v "complete"
+          lagoon raw --raw "query allProjects {
+            allProjects {
+            name
+              environments(type: PRODUCTION) {
+                name
+                deployments(limit: 1) {
+                  status
+                  created
+                }
+              }
+            }
+          }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status != "complete") | ($name) + ": " + (.status)' 
 
     sites:grep-in-deploy-log:
       desc: |


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Fetch deployment status for all projects in a single GraphQL query. This should be much more efficient compared to listing all projects and then retrieving the deployment status for each of them.

#### Should this be tested by the reviewer and how?

Try to run the task yourself.