### PR TITLE
add cron-jobs to moduletest

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -75,6 +75,20 @@ $SECONDARY_DOMAINS
         schedule: "${IMPORT_TRANSLATIONS_CRON}"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-cms/translations/da.config.po
         service: cli
+  moduletest:
+    cronjobs:
+      - name: drush cron
+        schedule: "M/15 * * * *"
+        command: drush cron
+        service: cli
+      - name: import translations
+        schedule: "${IMPORT_TRANSLATIONS_CRON}"
+        command: drush locale-check && drush locale-update
+        service: cli
+      - name: import danish config translations
+        schedule: "${IMPORT_TRANSLATIONS_CRON}"
+        command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-cms/translations/da.config.po
+        service: cli
 
 container-registries:
   github:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR activates the cron-jobs, which should fix integrations that aren't working one moduletest at the moment due to missing tokens. 

#### Should this be tested by the reviewer and how?
I have rolled it out on Taarnby, se please check there if this fixes it. 

#### Any specific requests for how the PR should be reviewed?
Read it through.

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-174