### PR TITLE
Aks 1.28

### DIFF
--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -18,7 +18,7 @@ module "environment" {
   # When copying this value, consider leaving it out and falling back to the
   # default of 102400.
   sql_storage_mb        = 409600
-  control_plane_version = "1.27.9"
+  control_plane_version = "1.28.9"
 }
 
 # Outputs, for values that comes straight from the dpl-platform-environment

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -8,10 +8,10 @@ module "environment" {
   lagoon_domain_base = "dplplat01.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
-    "app4" : { min : 7, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },
+    "app4" : { min : 11, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },
     "admin6": { count : 1, vm : "Standard_E4s_v3", role : "admin", max_pods : 60, },
   }
-  node_pool_system_count = 2
+  node_pool_system_count = 3
   # We've increased this quite a bit to test performance. The ideal starting-
   # point seems to be in the range 102400 - 204800 to get enough IOPS to
   # maintain performance during a Drupal site-install.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Upgrades AKS kubernetes to 1.28.

Has been executed in environment.

#### What are the relevant tickets?

DDFDRIFT-116