### PR TITLE
Lower max builds concurrent in lagoon to 5

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -8,7 +8,7 @@ lagoon-build-deploy:
     - "--harbor-username=admin"
     - "--harbor-password=$HARBOR_ADMIN_PASS"
     - "--enable-qos"
-    - "--qos-max-builds=15"
+    - "--qos-max-builds=5"
   rabbitMQUsername: "lagoon"
   rabbitMQPassword: "$RABBITMQ_PASS"
   rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Lowers concurrency when building sites in Lagoon.

Has been executed in infrastructure.

#### What are the relevant tickets?

DDFDRIFT-96