### PR TITLE
Seperate versions between moduletest and main

### DIFF
--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -34,6 +34,19 @@ function getSiteDplCmsRelease {
     return
 }
 
+
+function getWebmasterDplCmsRelease {
+    local wmRelease
+    wmRelease=$(yq eval ".sites.${1}.webmaster-cms-version" "${2}")
+    if [[ "${wmRelease}" == "null" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "${wmRelease}"
+    return
+}
+
 function getSiteReleaseImageRepository {
     local repository
     repository=$(yq eval ".sites.${1}.releaseImageRepository" "${2}")

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -37,7 +37,7 @@ function getSiteDplCmsRelease {
 
 function getWebmasterDplCmsRelease {
     local wmRelease
-    wmRelease=$(yq eval ".sites.${1}.webmaster-cms-version" "${2}")
+    wmRelease=$(yq eval ".sites.${1}.moduletest-dpl-cms-release" "${2}")
     if [[ "${wmRelease}" == "null" ]]; then
         echo ""
         return

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -18,6 +18,7 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.35.1"
     plan: webmaster
+    moduletest-dpl-cms-release: "2024.32.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -38,7 +38,7 @@ sites:
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
     plan: webmaster
-    webmaster-cms-version: "2024.32.1"
+    moduletest-dpl-cms-release: "2024.32.1"
     <<: *default-release-image-source
   # Production sites
   aabenraa:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -38,7 +38,7 @@ sites:
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
     plan: webmaster
-    webmaster-cms-version: "2024.27.1"
+    webmaster-cms-version: "2024.32.1"
     <<: *default-release-image-source
   # Production sites
   aabenraa:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -38,6 +38,7 @@ sites:
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
     plan: webmaster
+    webmaster-cms-version: "2024.27.1"
     <<: *default-release-image-source
   # Production sites
   aabenraa:
@@ -461,7 +462,6 @@ sites:
       - nginx.main.kobenhavn.dplplat01.dpl.reload.dk
       - varnish.main.kobenhavn.dplplat01.dpl.reload.dk
     plan: webmaster
-    webmaster-cms-version: 2024.27.1
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
     <<: *webmaster-release-image-source
   koge:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR allows us to have seperate versions on WM and prod sites

#### Should this be tested by the reviewer and how?
Read it through and test it on canary 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-154