### PR TITLE
DRAFT: Make it hard to deploy a release with out at least two sets of eye having seen the changes

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -897,6 +897,26 @@ tasks:
           fi
       preconditions:
       - *require_site
+      - &require_clean_state {
+          sh: "[
+            current_branch=$(git branch --show-current)
+            if [ 'current_branch' != 'main' ]; then
+              echo 'Can't deploy if not on main branch'
+              exit 1
+            fi
+            if ! git diff-index --quiet HEAD --; then
+              echo 'Can't deploy if there's changes on the branch'
+              exit 1
+            fi
+            exit 0 #
+          ]",
+          msg: "############################################################ \n
+                \n
+                It's not possible to deploy from other branches than main.\n
+                Furthermore your state has to be clean \n
+                \n
+                ############################################################"
+        }
 
     site:autoscaler:
       desc: Runs the a dpladm setup of horizontal autoscaler, making sure the site has an autoscaler configured

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -908,7 +908,7 @@ tasks:
               echo 'Can't deploy if there's changes on the branch'
               exit 1
             fi
-            exit 0 #
+            exit 0
           ]",
           msg: "############################################################ \n
                 \n

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -898,18 +898,7 @@ tasks:
       preconditions:
       - *require_site
       - &require_clean_state {
-          sh: "[
-            current_branch=$(git branch --show-current)
-            if [ 'current_branch' != 'main' ]; then
-              echo 'Can't deploy if not on main branch'
-              exit 1
-            fi
-            if ! git diff-index --quiet HEAD --; then
-              echo 'Can't deploy if there's changes on the branch'
-              exit 1
-            fi
-            exit 0
-          ]",
+          sh: "[./dpladm/bin/require-clean-state.sh]",
           msg: "############################################################ \n
                 \n
                 It's not possible to deploy from other branches than main.\n

--- a/infrastructure/dpladm/bin/require-clean-state.sh
+++ b/infrastructure/dpladm/bin/require-clean-state.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Start a KK Shell session
+#
+# Syntax:
+#  dplsh [-p profile-name] [additional shell args]
+#
+set -euo pipefail
+echo "testing state"
+# Should be main to run
+# current_branch=$(git branch --show-current)
+# if [ 'current_branch' != 'canary' ]; then
+#   echo 'Can't deploy if not on main branch'
+#   exit 1
+# fi
+# if [! git diff-index --quiet HEAD --]; then
+#   echo 'Can't deploy if there's changes on the branch'
+#   exit 1
+# fi
+exit 0


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR attempts to hinde the error from last week where I deployed from a non-main branch in an unclean state. To phrase it a little differently: Try to ensure that a version bump mr has been approved by someone on the team before it is released

#### Should this be tested by the reviewer and how?
This can be tested on canary for now with the command `site:sync SITE=canary`. It should fail as you're not on the main branch. 
You should also test it by changing branch name from `main` to `prevent-unsafe-releases` and making a change somewhere. This should also be caught. 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-183