### PR TITLE
add a staging site

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -24,11 +24,9 @@ sites:
   staging:
     name: "Staging"
     description: "A site to test new releases on"
-    releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-    releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.33.0"
+    deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
     plan: webmaster
-    deploy_key:
+    <<: *webmaster-release-image-source
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,13 +14,21 @@ sites:
   # Testing and instructional sites
   canary:
     name: "Canary"
-    description: "A site to test new releases on"
+    description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.36.0"
     plan: webmaster
     moduletest-dpl-cms-release: "2024.36.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
+  staging:
+    name: "Staging"
+    description: "A site to test new releases on"
+    releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+    releaseImageName: dpl-cms-source
+    dpl-cms-release: "2024.33.0"
+    plan: webmaster
+    deploy_key:
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It adds a staging library site for DDF to test on. This allows us to go back to using canary for testing all sorts of things in a sandboxed yet production like environment

#### Should this be tested by the reviewer and how?
Just read it

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-189