### PR TITLE
Add proxy_upstream_name to nginx logging

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -7,7 +7,7 @@ controller:
     log-format-upstream: '{"time": "$time_iso8601", "remote_addr": "$proxy_add_x_forwarded_for", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$req_id",
       "bytes_sent": $bytes_sent, "request_time": $request_time, "status":$status, "vhost": "$host", "request_proto": "$server_protocol",
       "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time,"method": "$request_method", "http_referrer": "$http_referer",
-      "http_user_agent": "$http_user_agent" }'
+      "http_user_agent": "$http_user_agent", "proxy_upstream_name": "$proxy_upstream_name" }'
     # Default client_max_body_size is 1m, which is too small for our needs.
     # We align this with the value in Lagoon itself.
     # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size


### PR DESCRIPTION
#### What does this PR do?
`proxy_upstream_name` is part of the default logging, but when we changed to custom logging, it was left out. This adds it back in, into the custom logging.

#### Should this be tested by the reviewer and how?
Should not be necessary

#### Any specific requests for how the PR should be reviewed?
Nope

#### What are the relevant tickets?
None - for now.