### PR TITLE
Redirect legacy paths for library search and materials to new paths

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
@@ -1,0 +1,31 @@
+# Redirect paths for library search and materials to new urls.
+#
+# For all redirects we:
+# - Use permanent redirects to ensure that the new urls are picked up properly
+#   by search engines.
+# - Strip all query parameters in the process as we do not have a reliable way
+#   to transform these.
+
+# Redirect search queries
+#
+# Legacy paths:
+# - /search/ting/harry potter
+# - /search/ting/harry%20potter?&facets%5B%5D=facet.category%3Avoksenmaterialer
+# - /search/ting/harry%20potter?page=1
+# New path:
+# - /search?q=harry%2520potter
+rewrite ^/search/ting/([^/?]+) /search?q=$1? permanent;
+
+# Redirect materials.
+# The legacy system had separate paths for works (collections) and
+# manifestations (objects). The current system only promoted works so redirect
+# both to the work url.
+# This only works because there currently is a simple translation from the
+# id (pid) of a manifestation to the id of the corresponding work.
+#
+# Legacy paths:
+# - /ting/collection/870970-basis%3A47086868
+# - /ting/object/870970-basis%3A47086868
+# New path:
+# - /work/work-of:870970-basis%3A47086868
+rewrite ^/ting/(object|collection)/([^/?]+) /work/work-of:$2? permanent;

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
@@ -21,6 +21,10 @@ RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_modules_local.
 COPY lagoon/conf/nginx/server_append_drupal_rewrite_registration.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_registration.conf
 
+COPY lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_legacy_search_works.conf
+RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_rewrite_legacy_search_works.conf
+
+# Configuration targeted for non-local development.
 COPY lagoon/conf/nginx/metrics /app/web/_metrics
 COPY lagoon/conf/nginx/server_append_drupal_serve_metrics.conf /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_drupal_serve_metrics.conf


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This is a mirror of danskernesdigitalebibliotek/dpl-cms#1508 which applies the change for the NGINX image to the environment template.

If accepted then we must ensure that the changes to the template are propagated to the sites.

#### Should this be tested by the reviewer and how?

Consider checking the test in the danskernesdigitalebibliotek/dpl-cms#1508

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDFFORM-978