### PR TITLE
up default and webmaster releases to 35.1 but let 3 libraries stay on 33

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -7,7 +7,7 @@ x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.35.1"
-x-stay-on-33.1: &stay-on-33
+x-stay-on-33: &stay-on-33
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.33.0"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,11 +2,15 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.33.0"
+  dpl-cms-release: "2024.35.1"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.32.1"
+  dpl-cms-release: "2024.35.1"
+x-stay-on-33.1: &stay-on-33
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
+  dpl-cms-release: "2024.33.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -18,7 +22,7 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.35.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.32.1"
+    moduletest-dpl-cms-release: "2024.35.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   cms-school:
     name: "CMS-skole"
@@ -39,7 +43,7 @@ sites:
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.32.1"
+    moduletest-dpl-cms-release: "2024.35.1"
     <<: *default-release-image-source
   # Production sites
   aabenraa:
@@ -85,7 +89,7 @@ sites:
       - www.albertslundbibliotek.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *default-release-image-source
+    <<: *stay-on-33
   allerod:
     name: "Allerød Biblioteker"
     description: "The library site for Allerød"
@@ -661,7 +665,7 @@ sites:
     description: "The library site for Roskilde"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfCXTAe50+d/RUIu8JSctoCSzfJoEMtZ2OY0AUQdZgo"
     plan: webmaster
-    <<: *default-release-image-source
+    <<: *stay-on-33
   rudersdal:
     name: "Rudersdal Bibliotekerne"
     description: "The library site for Rudersdal"
@@ -691,7 +695,7 @@ sites:
       - www.silkeborgbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *default-release-image-source
+    <<: *stay-on-33
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It releases 2024.35.1 to almost all libraries, but keeps Roskilde, Silkeborg and Albertslund on 33.

#### Should this be tested by the reviewer and how?
Read it throug. Especially the tag for the ones staying on 33

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-200