### PR TITLE
Use force when deleting environments during cleanup

### DIFF
--- a/infrastructure/task/scripts/cleanup-dev-envs.sh
+++ b/infrastructure/task/scripts/cleanup-dev-envs.sh
@@ -47,9 +47,9 @@ echo "$DEV_ENVS" | while read -r environment; do
     echo "PR #$PR_NUMBER is $PR_STATUS. Closing development environment: $ENV_NAME."
 
     if [ "$DRY_RUN" = true ]; then
-      echo "Dry-run: lagoon delete environment -p \"$LAGOON_PROJECT\" -e \"$ENV_NAME\""
+      echo "Dry-run: lagoon delete environment -p \"$LAGOON_PROJECT\" -e \"$ENV_NAME\" --force"
     else
-      lagoon delete environment -p "$LAGOON_PROJECT" -e "$ENV_NAME"
+      lagoon delete environment -p "$LAGOON_PROJECT" -e "$ENV_NAME" --force
     fi
   fi
 done;


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Use force when deleting environments during cleanup

Otherwise the script will stop after deleting a single environment.

Using --force uses yes for interactive prompts and allows the script to continue across all environments.


Before:

```
➜  scripts git:(main) ./cleanup-dev-envs.sh
PR #1440 is CLOSED. Closing development environment: pr-1440.
✔ Yes
Result: success
➜  scripts git:(main) ./cleanup-dev-envs.sh
PR #1228 is CLOSED. Closing development environment: pr-1228.
✔ Yes
Result: success
➜  scripts git:(main) ./cleanup-dev-envs.sh
PR #1476 is CLOSED. Closing development environment: pr-1476.
✔ Yes
Result: success
```

After

```
➜  scripts git:(main) ✗ ./cleanup-dev-envs.sh
PR #1478 is CLOSED. Closing development environment: pr-1478.
Result: success
PR #1521 is CLOSED. Closing development environment: pr-1521.
Result: success
PR #1525 is CLOSED. Closing development environment: pr-1525.
Result: success
```

#### Should this be tested by the reviewer and how?

Try to run the script without `--dry-run`.
