### PR TITLE
Remove secondary domains from Køge bibliotek

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -476,8 +476,6 @@ sites:
     primary-domain: www.koegebib.dk
     secondary-domains:
       - koegebib.dk
-      - www.koegebibliotekerne.dk
-      - koegebibliotekerne.dk
     autogenerateRoutes: true
     <<: *default-release-image-source
   kolding:


### PR DESCRIPTION
#### What does this PR do?
Removes secondary domains from Køge Bibliotek, which they want to manage themselves.

#### Should this be tested by the reviewer and how?
No

#### Any specific requests for how the PR should be reviewed?
No

#### What are the relevant tickets?
None