### PR TITLE
Release 2024.37.0 to moduletest sites for webmaster and main sites for others

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,12 +2,12 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.36.0"
+  dpl-cms-release: "2024.37.0"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.35.1"
-  moduletest-dpl-cms-release: "2024.36.0"
+  moduletest-dpl-cms-release: "2024.37.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Releases latest release 2024.37.0 to sites on redaktør plan and moduletest sites on webplatster plan.
