### PR TITLE
Use latest version on some webmaster sites

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -8,6 +8,13 @@ x-webmaster: &webmaster-release-image-source
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.35.1"
   moduletest-dpl-cms-release: "2024.37.0"
+# Some sites on the webmaster plan wish to track the same release as
+# sites do per default in dpl-cms-release.
+x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
+  # Reference default before webmaster anchor as YAML references will not
+  # override existing keys.
+  <<: *default-release-image-source
+  <<: *webmaster-release-image-source
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -33,14 +33,14 @@ sites:
     description: "A site to test new releases on"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmaster-with-defaults-release-image-source
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmaster-with-defaults-release-image-source
   bibliotek-test:
     name: "Bibliotekstest"
     description: "Et site hvor bibliotekerne kan teste"
@@ -702,7 +702,7 @@ sites:
       - www.silkeborgbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmaster-with-defaults-release-image-source
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

[Add an anchor for webmaster sites using the latest version on main](https://github.com/danskernesdigitalebibliotek/dpl-platform/commit/89bce9345c8fb3204bd5c4b35e0e6a6b4c6162c5)

Normally webmaster sites use a previous version on their main
(production) environment and the latest version on their moduletest
environment.

However some sites want to use the latest version on both
environments.

Create an anchor to use for these sites.

Reference the new anchor for CMS School and Silkeborg as requested by
the business.

Reference the new anchor on staging to ensure that this follows the
latest version. This makes sense to enable testing there.

#### Should this be tested by the reviewer and how?

Deploy the changes to the three sites in question.

#### Any specific requests for how the PR should be reviewed?

One has to understand the intricacies of mulitple YAML references, overrides etc. to understand how the new anchor works.
This is not optimalt but I fear that we will forget to update these sites otherwise in the future.
