### PR TITLE
Deploy release 2024.38.1 on Canary

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -17,9 +17,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.37.0"
+    dpl-cms-release: "2024.38.0"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.37.0"
+    moduletest-dpl-cms-release: "2024.38.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   staging:
     name: "Staging"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -17,9 +17,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2024.38.0"
+    dpl-cms-release: "2024.38.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.38.0"
+    moduletest-dpl-cms-release: "2024.38.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   staging:
     name: "Staging"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2024.38.1 on Canary. Release 2024.38.0 turns out to cause problems during deployments. Addressing this required another release.

This has already been applied.
