### PR TITLE
Add tolerations and affinity to lagoon docker host and ingress-controller

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -30,10 +30,10 @@ controller:
       service.beta.kubernetes.io/azure-load-balancer-internal: "false"
       service.beta.kubernetes.io/azure-load-balancer-resource-group: "${RESOURCE_GROUP}"
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   admissionWebhooks:
     patch.nodeSelector:
-      beta.kubernetes.io/os: linux
+      kubernetes.io/os: linux
   # Since v1.9.0, Nginx server snippets are disabled by default. However, Lagoon
   # relies on them to be available for ingress definitions in order to prohibit
   # dev environments from being indexed by search engines. See:

--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -19,6 +19,7 @@ controller:
     minReplicas: 5
     maxReplicas: 15
     targetCPUUtilizationPercentage: null
+    targetMemoryUtilizationPercentage: 80
   resources:
     requests:
       cpu: null # lets not worry about CPU for now

--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -18,10 +18,11 @@ controller:
     enabled: true
     minReplicas: 5
     maxReplicas: 15
+    targetCPUUtilizationPercentage: null
   resources:
     requests:
-      cpu: 300m
-      memory: 1100Mi
+      cpu: null # lets not worry about CPU for now
+      memory: 500Mi
   service:
     loadBalancerIP: "${INGRESS_IP}"
     externalTrafficPolicy: "Local"

--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -39,3 +39,17 @@ controller:
   # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#allow-snippet-annotations
   # https://docs.lagoon.sh/using-lagoon-the-basics/going-live/#production-environment
   allowSnippetAnnotations: true
+  tolerations:
+    - key: noderole.dplplatform
+      operator: Equal
+      value: prod
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - prod

--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -39,6 +39,3 @@ controller:
   # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#allow-snippet-annotations
   # https://docs.lagoon.sh/using-lagoon-the-basics/going-live/#production-environment
   allowSnippetAnnotations: true
-defaultBackend:
-  nodeSelector:
-    beta.kubernetes.io/os: linux

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -44,3 +44,19 @@ dbaas-operator:
       password: "$SQL_PASSWORD"
       port: "3306"
       user: "$SQL_USER@$SQL_HOSTNAME"
+
+dockerHost:
+  tolerations:
+  - key: noderole.dplplatform
+    operator: Equal
+    value: build
+    effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: noderole.dplplatform
+              operator: In
+              values:
+                - build


### PR DESCRIPTION
#### What does this PR do?
We isolate lagoon docker host to its own node pool, and we move the ingress controllers to the production nodes. We also adjust HPA settings for the ingress controllers.

#### Should this be tested by the reviewer and how?
No

#### Any specific requests for how the PR should be reviewed?
No

#### What are the relevant tickets?
DDFDRIFT-86