### PR TITLE
Release 2024.35.2 on Customizable Canary

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -32,7 +32,7 @@ sites:
     name: "Customizable bibliotek - eksempel"
     description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
     plan: webmaster
-    dpl-cms-release: "2024.35.1"
+    dpl-cms-release: "2024.35.2"
     moduletest-dpl-cms-release: "2024.38.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -28,6 +28,13 @@ sites:
     plan: webmaster
     moduletest-dpl-cms-release: "2024.38.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
+  customizable-canary:
+    name: "Customizable bibliotek - eksempel"
+    description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
+    plan: webmaster
+    dpl-cms-release: "2024.35.1"
+    moduletest-dpl-cms-release: "2024.38.1"
+    deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"
     description: "A site to test new releases on"
@@ -47,12 +54,6 @@ sites:
     importTranslationsCron: "0 * * * *"
     plan: webmaster
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
-    <<: *webmaster-release-image-source
-  customizable-canary:
-    name: "Customizable bibliotek - eksempel"
-    description: "Eksempel på bibliotek der kører på 'webmaster' plan, og derfor har et modultest-miljø"
-    deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
-    plan: webmaster
     <<: *webmaster-release-image-source
   # Production sites
   aabenraa:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

[Update customizable canary for testing](https://github.com/danskernesdigitalebibliotek/dpl-platform/commit/b33546d3e8243233c32d0eebe6f8e836f2e3f305)

We need an environment which follows the webmaster release cycle and
can be used for testing.

Move the definition of customizable canary next to the current canary
environment and replace the current reference defining release numbers
with explicit release numbers.

Now we can deploy release 2024.35.2 to Customizable Canary.

This has already been applied.
