### PR TITLE
release 40.0 on editor sites, webmaster's moduletest and onto those w…

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,19 +2,19 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.39.1"
+  dpl-cms-release: "2024.40.0"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.39.1"
-  moduletest-dpl-cms-release: "2024.39.1"
+  moduletest-dpl-cms-release: "2024.40.0"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   # Reference default before webmaster anchor as YAML references will not
   # override existing keys.
   <<: *default-release-image-source
-  moduletest-dpl-cms-release: "2024.39.1"
+  moduletest-dpl-cms-release: "2024.40.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
…ebmasters who've asked to have weekly releases in production - as well as their moduletest sites

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It releases 40.0 to editor, webmaster's moduletests as well to the the production sites of the webmasters who've asked for weekly releases.

#### Should this be tested by the reviewer and how?
No

#### Any specific requests for how the PR should be reviewed?
Read it through

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-236