### PR TITLE
Task for cluster deploy mode

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -238,9 +238,9 @@ tasks:
           --resource-group rg-env-dplplat01
           --node-count 5
 
-    cluster:mode:business:
+    cluster:mode:reset:
       deps: [cluster:auth , lagoon:cli:config]
-      desc: "Set the cluster in release mode by adding additional nodes to release critical node pools"
+      desc: "Reset changes to the cluster mode returning it to standard operations."
       cmds:
         - az aks nodepool scale
           --cluster-name aks-dplplat01-01

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -235,7 +235,10 @@ tasks:
         - az aks nodepool scale
           --cluster-name aks-dplplat01-01
           --nodepool-name system2
-          --resource-group rg-env-dplplat01
+          --resource-group
+            $(
+              terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
+            )
           --node-count 5
 
     cluster:mode:reset:
@@ -250,7 +253,10 @@ tasks:
         - az aks nodepool scale
           --cluster-name aks-dplplat01-01
           --nodepool-name system2
-          --resource-group rg-env-dplplat01
+          --resource-group
+            $(
+              terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
+            )
           --node-count 3
 
     support:provision:cert-manager:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -223,6 +223,21 @@ tasks:
       cmds:
         - task/scripts/promote-workloads-to-prod-nodes.sh
 
+    cluster:mode:release:
+      deps: [cluster:auth , lagoon:cli:config]
+      desc: "Set the cluster in release mode by adding additional nodes to release critical node pools"
+      cmds:
+        - az aks nodepool scale
+          --cluster-name aks-dplplat01-01
+          --nodepool-name app6
+          --resource-group rg-env-dplplat01
+          --node-count 4
+        - az aks nodepool scale
+          --cluster-name aks-dplplat01-01
+          --nodepool-name system2
+          --resource-group rg-env-dplplat01
+          --node-count 5
+
     support:provision:cert-manager:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -238,6 +238,21 @@ tasks:
           --resource-group rg-env-dplplat01
           --node-count 5
 
+    cluster:mode:business:
+      deps: [cluster:auth , lagoon:cli:config]
+      desc: "Set the cluster in release mode by adding additional nodes to release critical node pools"
+      cmds:
+        - az aks nodepool scale
+          --cluster-name aks-dplplat01-01
+          --nodepool-name app6
+          --resource-group rg-env-dplplat01
+          --node-count 2
+        - az aks nodepool scale
+          --cluster-name aks-dplplat01-01
+          --nodepool-name system2
+          --resource-group rg-env-dplplat01
+          --node-count 3
+
     support:provision:cert-manager:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It adds the ability to set the cluster into deploy mode and back into business mode

#### Should this be tested by the reviewer and how?
Please run the both tasks on after the other.
After having set the cluster in deploy mode, go here: https://portal.azure.com/#@reloadas.onmicrosoft.com/resource/subscriptions/8ac8a259-5bb3-4799-bd1e-455145b12550/resourceGroups/rg-env-dplplat01/providers/Microsoft.ContainerService/managedClusters/aks-dplplat01-01/nodePools
The app6 nodepool should now have 4 nodes and the system2 nodepool should have 5. 

Then set the cluster back into business mode and check that, the app6 pool has 2 nodes and the system2 pool has 3 nodes. 

#### Any specific requests for how the PR should be reviewed?
Run the tasks and read it through

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-240