### PR TITLE
Release 44.0

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -385,7 +385,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmaster-skipping-44
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,7 +14,7 @@ x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   # Reference default before webmaster anchor as YAML references will not
   # override existing keys.
   <<: *default-release-image-source
-  moduletest-dpl-cms-release: "2024.43.1"
+  moduletest-dpl-cms-release: "2024.44.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.43.1"
+  dpl-cms-release: "2024.44.0"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -15,6 +15,11 @@ x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   # override existing keys.
   <<: *default-release-image-source
   moduletest-dpl-cms-release: "2024.44.0"
+x-webmasters-skipping-update-44.0: &webmaster-skipping-44
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
+  dpl-cms-release: "2024.39.1"
+  moduletest-dpl-cms-release: "2024.44.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -6,8 +6,8 @@ x-defaults: &default-release-image-source
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.39.1"
-  moduletest-dpl-cms-release: "2024.43.1"
+  dpl-cms-release: "2024.43.1"
+  moduletest-dpl-cms-release: "2024.44.0"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -26,7 +26,7 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.43.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.43.1"
+    moduletest-dpl-cms-release: "2024.44.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -34,8 +34,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2024.39.1"
-    moduletest-dpl-cms-release: "2024.39.1"
+    dpl-cms-release: "2024.43.1"
+    moduletest-dpl-cms-release: "2024.43.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It releases new versions to the libraries. 
The editors and weekly updated webmasters will go directly 44.0, as will the regular webmasters moduletest.
The webmasters on a regular schedule will have their production sites updated to last weeks update (43.1).
Herning will, as requested(https://reload.zulipchat.com/#narrow/channel/419623-DDF.2B/topic/Release.202024.2E44.2E0/near/479639216), stay on 39.1 for another week. Their moduletest however will be upated to 44.0.


#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?
read it 

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-247