### PR TITLE
only build 8 environments at a time

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -8,7 +8,7 @@ lagoon-build-deploy:
     - "--harbor-username=admin"
     - "--harbor-password=$HARBOR_ADMIN_PASS"
     - "--enable-qos"
-    - "--qos-max-builds=10"
+    - "--qos-max-builds=8"
   rabbitMQUsername: "lagoon"
   rabbitMQPassword: "$RABBITMQ_PASS"
   rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This sets the number of parallel builds down to 8. 
We go a lot of errors when building 15 at the same time. 
We also got some errors while building 10 at a time, so I want to try to find level at which we have as close to none as possible.

#### Should this be tested by the reviewer and how?
No - this has been run already

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
