### PR TITLE
Deploy release 2024.44.1 to editor sites and module test sites for editors

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,19 +2,19 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.44.0"
+  dpl-cms-release: "2024.44.1"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.43.1"
-  moduletest-dpl-cms-release: "2024.44.0"
+  moduletest-dpl-cms-release: "2024.44.1"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   # Reference default before webmaster anchor as YAML references will not
   # override existing keys.
   <<: *default-release-image-source
-  moduletest-dpl-cms-release: "2024.44.0"
+  moduletest-dpl-cms-release: "2024.44.1"
 x-webmasters-skipping-update-44.0: &webmaster-skipping-44
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2024.44.1 to editor sites and module test sites for editors

This follows the practice from https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/weekly-release-to-editors-and-moduletests/#procedure-new-version-to-editors-and-moduletest-environments
