### PR TITLE
Task to reset all moduletests

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1099,6 +1099,16 @@ tasks:
       cmds:
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self; drush cr -y"
 
+    sites:webmaster:reset-moduletests:
+      desc: Reset all webmaster moduletests. It is possible to exempt some.
+      deps: [lagoon:cli:config]
+      vars:
+        webmasters:
+          sh: yq '... comments="" | .sites | with_entries(select(.value | has("plan"))) | keys | .[]' {{.dir_env}}/sites.yaml
+      cmds:
+        - for: { var: webmasters }
+          cmd: echo "{{.ITEM}}"
+
     sites:check-caa:
       desc: |
         Checks if a site's primary and secondary domains have CAA records registered, and if they do report it.

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1106,8 +1106,13 @@ tasks:
         webmasters:
           sh: yq '... comments="" | .sites | with_entries(select(.value | has("plan"))) | keys | .[]' {{.dir_env}}/sites.yaml
       cmds:
-        - for: { var: webmasters }
-          cmd: echo "{{.ITEM}}"
+        - for: ["canary", "customizable-canary"]
+          task: site:environment:sync
+          vars:
+            TARGET_PROJECT: "{{.ITEM}}"
+            TARGET_ENV: "moduletest"
+            SOURCE_PROJECT: "{{.ITEM}}"
+            SOURCE_ENV: "main"
 
     sites:check-caa:
       desc: |

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1085,6 +1085,20 @@ tasks:
       preconditions:
       - *require_site
 
+    site:environment:sync:
+      desc: |
+        Synchonizes all file and database tables from environment
+        to another on make on environment a complete copy of the source.
+      deps: [lagoon:cli:config]
+      dir: "{{.dir_env}}"
+      vars:
+        SOURCE_PROJECT: "{{.SOURCE_PROJECT}}"
+        SOURCE_ENV: "{{.SOURCE_ENV}}"
+        TARGET_PROJECT: "{{.TARGET_PROJECT}}"
+        TARGET_ENV: "{{.TARGET_ENV}}"
+      cmds:
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self; drush cr -y"
+
     sites:check-caa:
       desc: |
         Checks if a site's primary and secondary domains have CAA records registered, and if they do report it.

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1100,7 +1100,7 @@ tasks:
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self; drush cr -y"
 
     sites:webmaster:reset-moduletests:
-      desc: Reset all webmaster moduletests. It is possible to exempt some.
+      desc: Reset all webmaster moduletests
       deps: [lagoon:cli:config]
       vars:
         webmasters:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1106,7 +1106,7 @@ tasks:
         webmasters:
           sh: yq '... comments="" | .sites | with_entries(select(.value | has("plan"))) | keys | .[]' {{.dir_env}}/sites.yaml
       cmds:
-        - for: ["canary", "customizable-canary"]
+        - for: { var: webmasters }
           task: site:environment:sync
           vars:
             TARGET_PROJECT: "{{.ITEM}}"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It finds all webmasters and resets all their moduletest environments by copying their files and databases from prod to moduletest and then running another deploy. 

#### Should this be tested by the reviewer and how?
Don't run the task unless it needs to. I have a tested it on the a list of canaries. 
#### Any specific requests for how the PR should be reviewed?
Just read it

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-251