### PR TITLE
Task to restart failed deployements that are not from the dpl-cms project

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1146,7 +1146,7 @@ tasks:
 
     sites:redeploy-failed-deployments:
       deps: [lagoon:cli:config]
-      desc: redeployyes all failed deployments
+      desc: Redeploys all failed deployments
       cmds:
         - task/scripts/redeploy-failed-deployments.sh
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1134,7 +1134,7 @@ tasks:
           lagoon raw --raw "query allProjects {
             allProjects {
             name
-              environments(type: PRODUCTION) {
+              environments(type: DEVELOPMENT) {
                 name
                 deployments(limit: 1) {
                   status
@@ -1143,6 +1143,12 @@ tasks:
               }
             }
           }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status != "complete") | ($name) + ": " + (.status)' 
+
+    sites:redeploy-failed-deployments:
+      deps: [lagoon:cli:config]
+      desc: redeployyes all failed deployments
+      cmds:
+        - task/scripts/redeploy-failed-deployments.sh
 
     sites:grep-in-deploy-log:
       desc: |

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1134,7 +1134,7 @@ tasks:
           lagoon raw --raw "query allProjects {
             allProjects {
             name
-              environments(type: DEVELOPMENT) {
+              environments(type: PRODUCTION) {
                 name
                 deployments(limit: 1) {
                   status

--- a/infrastructure/task/scripts/redeploy-failed-deployments.sh
+++ b/infrastructure/task/scripts/redeploy-failed-deployments.sh
@@ -3,7 +3,7 @@
 # 80% of failed deployments is fixed by redeploying the failed deployment.
 # This script will help make that easier to do.
 
-echo "Will now start to redeployg failed deployments"
+echo "Will now start to redeploying failed deployments"
 echo "Finding failed main environments"
 
 FAILED_PRODUCTION_DEPLOYMENTS=$(lagoon raw --raw "query allProjects {

--- a/infrastructure/task/scripts/redeploy-failed-deployments.sh
+++ b/infrastructure/task/scripts/redeploy-failed-deployments.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# 80% of failed deployments is fixed by redeploying the failed deployment.
+# This script will help make that easier to do.
+
+echo "Will now start to redeployg failed deployments"
+echo "Finding failed main environments"
+
+FAILED_PRODUCTION_DEPLOYMENTS=$(lagoon raw --raw "query allProjects {
+  allProjects {
+  name
+    environments(type: PRODUCTION) {
+      name
+      deployments(limit: 1) {
+        status
+        created
+      }
+    }
+  }
+}" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status == "failed") | ($name)')
+
+echo "redeploying failed production environments"
+
+for deployment in $FAILED_PRODUCTION_DEPLOYMENTS; do
+  if [[ $deployment =~ "dpl-cms" ]]; then
+    continue
+  fi
+  echo "$deployment: deploying"
+  lagoon deploy latest -p "$deployment" -e "main" --force
+done
+
+echo "Finding failed development environments"
+
+FAILED_DEVELOPMENT_DEPLOYMENTS=$(lagoon raw --raw "query allProjects {
+  allProjects {
+  name
+    environments(type: DEVELOPMENT) {
+      name
+      deployments(limit: 1) {
+        status
+        created
+      }
+    }
+  }
+}" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status == "failed") | ($name)')
+
+echo "redeploying failed moduletest environments"
+
+for deployment in $FAILED_DEVELOPMENT_DEPLOYMENTS; do
+  if [[ $deployment =~ "dpl-cms" ]]; then
+    continue
+  fi
+  echo "$deployment: deploying"
+  lagoon deploy latest -p "$deployment" -e "moduletest" --force
+done
+
+echo "Done - all failed deployments has now be redeployed"

--- a/infrastructure/task/scripts/redeploy-failed-deployments.sh
+++ b/infrastructure/task/scripts/redeploy-failed-deployments.sh
@@ -19,7 +19,7 @@ FAILED_PRODUCTION_DEPLOYMENTS=$(lagoon raw --raw "query allProjects {
   }
 }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status == "failed") | ($name)')
 
-echo "redeploying failed production environments"
+echo "Redeploying failed production environments"
 
 for deployment in $FAILED_PRODUCTION_DEPLOYMENTS; do
   if [[ $deployment =~ "dpl-cms" ]]; then

--- a/infrastructure/task/scripts/redeploy-failed-deployments.sh
+++ b/infrastructure/task/scripts/redeploy-failed-deployments.sh
@@ -44,7 +44,7 @@ FAILED_DEVELOPMENT_DEPLOYMENTS=$(lagoon raw --raw "query allProjects {
   }
 }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status == "failed") | ($name)')
 
-echo "redeploying failed moduletest environments"
+echo "Redeploying failed moduletest environments"
 
 for deployment in $FAILED_DEVELOPMENT_DEPLOYMENTS; do
   if [[ $deployment =~ "dpl-cms" ]]; then


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This is hopefully a little nifty task that will make it faster and easier for us to redeploy failed deployments for both main and moduletest environments. 
I have done this as most deployment problems are solved by runnning them again. 
We should still investigate why deployments fail.

#### Should this be tested by the reviewer and how?
Just run it

#### Any specific requests for how the PR should be reviewed?
Read it and test it 

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-252