### PR TITLE
Authenticate against cluster before clearing certificate queue

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1194,6 +1194,7 @@ tasks:
           | xargs -n 1 -I % bash -c 'set -e; if (( $(curl -s https://varnish.main.%.dplplat01.dpl.reload.dk/ | grep "\"header__logo-desktop-link\"" -A 8 | grep "\"logo-fallback\s*\"" -A 4 | grep "Logo title (bold)" | wc -l) > 0 )); then echo "% not yet set up"; fi'
 
     certs:clear-queue:
+      deps: [cluster:auth]
       desc: |
         Because cert-manager sometimes hangs while provisioning certificates it helps to clear the whole queue
         of uncompleted certificates. This command removes any certificate that has an order not in either


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Authenticate against cluster before clearing certificate queue

If we do not have a proper kube context then running `task certs:clear-queue` from `dplsh` will fail:

```
E1106 08:51:06.924674      89 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1106 08:51:06.925045      89 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1106 08:51:06.927873      89 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1106 08:51:06.928069      89 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1106 08:51:06.930858      89 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```

Add cluster:auth as a dependency to ensure that we have a proper context setup.

#### Should this be tested by the reviewer and how?

Try to run `task certs:clear-queue` immediatly after starting `dplsh`.

#### Any specific requests for how the PR should be reviewed?

Try to run the task.

#### What are the relevant tickets?
