### PR TITLE
Ddfher 94 update php access

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/location_prepend_drupal_authorize.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/location_prepend_drupal_authorize.conf
@@ -1,6 +1,5 @@
 # This overrides the restriction in app.conf to access /core/authorize.php
-# We need acces in order to upload modules in Drupal.
+# We need access in order to upload modules in Drupal.
 location ~* ^(/core/authorize.php) {
   try_files /dev/null @php;
 }
-

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/location_prepend_drupal_update.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/location_prepend_drupal_update.conf
@@ -1,0 +1,13 @@
+# Allow access to update.php. Webmaster libraries need it so they can
+# run updates when upgrading custom modules.
+location ~* ^(/update.php) {
+  # We need this instead of the simpler `try_files /dev/null @php;`,
+  # as update.php uses PATH_INFO.
+  fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+  include        /etc/nginx/fastcgi.conf;
+  fastcgi_pass   ${NGINX_FASTCGI_PASS:-php}:9000;
+  # update.php apparently doesn't set any Cache-Control header, so
+  # Nginx falls back to the 30 day default set up in the Lagoon
+  # nginx-drupal image if we don't explicitly kill it here.
+  expires off;
+}

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/nginx.dockerfile
@@ -12,6 +12,9 @@ COPY --from=cli /app /app
 COPY lagoon/conf/nginx/location_prepend_drupal_authorize.conf /etc/nginx/conf.d/drupal/location_prepend_drupal_authorize.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/location_prepend_drupal_authorize.conf
 
+COPY lagoon/conf/nginx/location_prepend_drupal_update.conf /etc/nginx/conf.d/drupal/location_prepend_drupal_update.conf
+RUN fix-permissions /etc/nginx/conf.d/drupal/location_prepend_drupal_update.conf
+
 COPY lagoon/conf/nginx/server_append_disable_varnish_static_files.conf /etc/nginx/conf.d/drupal/server_append_disable_varnish_static_files.conf
 RUN fix-permissions /etc/nginx/conf.d/drupal/server_append_disable_varnish_static_files.conf
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Make `update.php` accessible. Webmaster libraries needs to use it to run module update hooks after uploading a new version of a custom module. Lagoon disables this per default.

#### What are the relevant tickets?

[DDFHER-94](https://reload.atlassian.net/browse/DDFHER-94)

[DDFHER-94]: https://reload.atlassian.net/browse/DDFHER-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ