### PR TITLE
Increase ingress-nginx client_header_buffer_size

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/ingress-nginx/ingres-nginx-values.template.yaml
@@ -13,6 +13,10 @@ controller:
     # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
     # and https://github.com/uselagoon/lagoon-images/blob/main/images/nginx/nginx.conf#L81
     proxy-body-size: "2048m"
+    # Default client_header_buffer_size is 1k in nginx, which results in 502
+    # errors for some applications, eg. large cookie headers.
+    # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#client-header-buffer-size
+    client-header-buffer-size: "8k"
   replicaCount: 2
   autoscaling:
     enabled: true


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This moves the ingress-nginx config away from the [default Nginx value of 1kb for `client_header_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size), and sets our own value of 8kb for that setting instead.

The reason for this change is that some incoming requests to the application containers are erroring with a message like this:

`2024/11/20 09:58:39 [error] 60431#60431: *30679622 upstream sent too big header while reading response header from upstream, client: 5.103.135.109, server: node.pr-1757.dpl-cms.dplplat01.dpl.reload.dk, request: "GET /auth/callback/unilogin?session_state=111b7164-1637-4836-87fc-fa6f4e957c53&code=5ad2f288-c3eb-4b95-b501-3430173fdf8a.111b7164-1637-4836-87fc-fa6f4e957c53.eb9dd6e6-07f1-41e2-9ad9-b777d9ce69af HTTP/2.0", upstream: "http://10.1.12.195:3000/auth/callback/unilogin?session_state=111b7164-1637-4836-87fc-fa6f4e957c53&code=5ad2f288-c3eb-4b95-b501-3430173fdf8a.111b7164-1637-4836-87fc-fa6f4e957c53.eb9dd6e6-07f1-41e2-9ad9-b777d9ce69af", host: "node.pr-1757.dpl-cms.dplplat01.dpl.reload.dk"`

This is from Grafana in the `ingress-nginx` namespace, and the code behind this works on the developer's local machine, so this tells me that the ingress controller config is the culprit here.

#### Should this be tested by the reviewer and how?

This needs to be rolled out to production, and cannot be tested locally (AFAIK).

#### What are the relevant tickets?

DDFBRA-217
