### PR TITLE
Release 47.1

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -7,7 +7,7 @@ x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.43.1"
-  moduletest-dpl-cms-release: "2024.46.0"
+  moduletest-dpl-cms-release: "2024.47.1"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.46.0"
+  dpl-cms-release: "2024.47.1"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -31,7 +31,7 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2024.43.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.44.0"
+    moduletest-dpl-cms-release: "2024.47.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -40,7 +40,7 @@ sites:
     releaseImageName: dpl-cms-source
     plan: webmaster
     dpl-cms-release: "2024.43.1"
-    moduletest-dpl-cms-release: "2024.43.1"
+    moduletest-dpl-cms-release: "2024.47.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,7 +14,7 @@ x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   # Reference default before webmaster anchor as YAML references will not
   # override existing keys.
   <<: *default-release-image-source
-  moduletest-dpl-cms-release: "2024.46.0"
+  moduletest-dpl-cms-release: "2024.47.1"
 x-webmasters-skipping-update-44.0: &webmaster-skipping-44
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -18,8 +18,8 @@ x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
 x-webmasters-skipping-update-44.0: &webmaster-skipping-44
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.39.1"
-  moduletest-dpl-cms-release: "2024.46.0"
+  dpl-cms-release: "2024.46.0"
+  moduletest-dpl-cms-release: "2024.47.1"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This releases 47.1 onto: 
editors production,
Webmaster modultests
Canary sites moduletests
It also upgrades Hernings prod to 46.0

#### Should this be tested by the reviewer and how?
This should be read through

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-260