### PR TITLE
Moduletestsyncing

### DIFF
--- a/docs/runbooks/reset-moduletest.md
+++ b/docs/runbooks/reset-moduletest.md
@@ -2,23 +2,21 @@
 
 ## When to use
 
-When a moduletest site need reseting
+When a moduletest site need resetting.
+
+## Prerequisites
+
+* An authenticated `az` cli. The logged in user must have full administrative
+  permissions to the platforms azure infrastructure.
+* A running [dplsh](using-dplsh.md) with `DPLPLAT_ENV` set to the platform
+  environment name.
 
 ## Procedure
 
-1. Find the moduletest site of the project that need reseting in the Lagoon UI
-2. Go to tasks
-3. Select "Copy files between environments", and set the source
-  to "main" and run the task. This queues the task and lagoon will run it when
-  it can.
-  There's some role/user restrictions in place by lagoon, which
-  makes the task fail, as it can't set the correct time on the files. If that
-  is the only
-  error, then it copied the files, and this step is done. Otherwise run it again
-4. Select "Copy database between environments", and set the source
-  to "main" and run the task
-5. Go to deployments and pres "deploy", this ensures that the state matches that
-  of the environment.
-6. Go the page URL and check that it looks alright
+From within `dplsh` run:
 
-The moduletest site is now reset
+```sh
+PROJECT=<site> task sites:webmaster:reset-moduletest
+```
+
+Where `<site>` is the site to reset.

--- a/docs/runbooks/ui-reset-moduletest.md
+++ b/docs/runbooks/ui-reset-moduletest.md
@@ -1,0 +1,29 @@
+# UI: Reset moduletest site
+
+## When to use
+
+When a moduletest site need resetting
+
+**Warning:** This procedure does not sync the site properly, as it
+doesn't delete files/tables that exists on moduletest but not in
+production. In many cases, this isn't a problem, but i some instances
+it could be. If in doubt, ask a platform engineer to do the sync.
+
+## Procedure
+
+1. Find the moduletest site of the project that need resetting in the Lagoon UI
+2. Go to tasks
+3. Select "Copy files between environments", and set the source
+  to "main" and run the task. This queues the task and lagoon will run it when
+  it can.
+  There's some role/user restrictions in place by lagoon, which
+  makes the task fail, as it can't set the correct time on the files. If that
+  is the only
+  error, then it copied the files, and this step is done. Otherwise run it again
+4. Select "Copy database between environments", and set the source
+  to "main" and run the task
+5. Go to deployments and pres "deploy", this ensures that the state matches that
+  of the environment.
+6. Go the page URL and check that it looks alright
+
+The moduletest site is now reset

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1100,6 +1100,19 @@ tasks:
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db; exit;"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 
+    sites:webmaster:reset-moduletest:
+      desc: Reset webmaster moduletest
+      deps: [lagoon:cli:config]
+      vars:
+        PROJECT: "{{.PROJECT}}"
+      cmds:
+        - task: site:environment:sync
+          vars:
+            TARGET_PROJECT: "{{.PROJECT}}"
+            TARGET_ENV: "moduletest"
+            SOURCE_PROJECT: "{{.PROJECT}}"
+            SOURCE_ENV: "main"
+
     sites:webmaster:reset-moduletests:
       desc: Reset all webmaster moduletests
       deps: [lagoon:cli:config]
@@ -1108,12 +1121,9 @@ tasks:
           sh: yq '... comments="" | .sites | with_entries(select(.value | has("plan"))) | keys | .[]' {{.dir_env}}/sites.yaml
       cmds:
         - for: { var: webmasters }
-          task: site:environment:sync
+          task: sites:webmaster:reset-moduletest
           vars:
-            TARGET_PROJECT: "{{.ITEM}}"
-            TARGET_ENV: "moduletest"
-            SOURCE_PROJECT: "{{.ITEM}}"
-            SOURCE_ENV: "main"
+            PROJECT: "{{.ITEM}}"
 
     sites:check-caa:
       desc: |


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Adds `sites:webmaster:reset-moduletest` task and updates resetting moduletest runbooks.

We're getting requests to reset sigle sites, so a command that does exactly that is handy and eliminates the risk of fumbling the four required parameters to `site:environment:sync`.

Added note to resetting module rulebook that it's in fact not quite a proper reset.

Added the missing rulebook about using resetting moduletest sites using `dplsh` to aid discoverability.