### PR TITLE
Remove unused step

### DIFF
--- a/docs/runbooks/weekly-release-to-editors-and-moduletests.md
+++ b/docs/runbooks/weekly-release-to-editors-and-moduletests.md
@@ -16,34 +16,34 @@ the production environments of webmasters.
 
 ## Procedure: New version to editors and moduletest environments
 
-1. In your local environment ensure that your checkout of the `main` branch for
-   `dpl-platform` is up to date.
+1. In your local environment ensure that your checkout of the `main`
+   branch for `dpl-platform` is up to date.
 2. Create a new branch from `main`.
-3. Now update `infrastructure/environments/dplplat01/sites.yaml`.
-    The 'x-defaults' anchors' 'dpl-cms-release' tag should be bumped to the
-    new version. Then update the 'moduletest-dpl-cms-release' of 'x-webmaster'
-    to the same version. Update the same property for the
-    'x-webmaster-with-defaults' anchor.
-4. Commit the change and push your branch to GitHub and create a pull request.
+3. Now update `infrastructure/environments/dplplat01/sites.yaml`. The
+    'x-defaults' anchors' 'dpl-cms-release' tag should be bumped to
+    the new version. Then update the 'moduletest-dpl-cms-release' of
+    'x-webmaster' to the same version. Update the same property for
+    the 'x-webmaster-with-defaults' anchor.
+4. Commit the change and push your branch to GitHub and create a pull
+   request.
 5. Request a review for the change and wait for approval.
 6. Start `dplsh` from the `/infrastructure` directory of your local
    environment by running `../tools/dplsh/dplsh.sh`
-7. Run `task cluster:mode:release` to get more nodes while deploying.
-8. Run `task sites:sync` from `dplsh` to deploy the changes.
-9. If there are any Terraform changes then do not apply them, abort the
-   deployment and consult the platform team.
-10. Open the Deployments list page within the Lagoon UI to see all running and
-   queued deployments.
-11. Wait for all the deployment to complete.
-12. Run `task sites:incomplete-deployments` to identify any failed deployments.
-13. If some deployments did not complete determine if the error relates to the
-    platform or the application.
-14. For all platform-related errors try to redeploy the environment from
-    the Lagoon UI.
-15. Merge the pull request once the deployment completes.
-16. Run `task cluster:adjust:resource-request` from `dplsh`.
-17. Run `task cluster:promote-workloads-to-prod` from `dplsh`.
-18. Run 'task cluster:mode:reset' from `dplsh`.
+7. Run `task sites:sync` from `dplsh` to deploy the changes.
+8. If there are any Terraform changes then do not apply them, abort
+   the deployment and consult the platform team.
+9. Open the Deployments list page within the Lagoon UI to see all
+   running and queued deployments.
+10. Wait for all the deployment to complete.
+11. Run `task sites:incomplete-deployments` to identify any failed
+    deployments.
+12. If some deployments did not complete determine if the error
+    relates to the platform or the application.
+13. For all platform-related errors try to redeploy the environment
+    from the Lagoon UI.
+14. Merge the pull request once the deployment completes.
+15. Run `task cluster:adjust:resource-request` from `dplsh`.
+16. Run `task cluster:promote-workloads-to-prod` from `dplsh`.
 
 ## Procedure: a some sites fails to deploy
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It remove steps that we do not want to use at this moment, as they move the pod around. It is not possible for us to move pod around without interupting the live sites, as no PodDisruptionBudget has been installed

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
