### PR TITLE
Update editors ond webmasters to 2024.49.0

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,28 +2,17 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.48.0"
+  dpl-cms-release: "2024.49.0"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.47.2"
-  moduletest-dpl-cms-release: "2024.48.1"
+  moduletest-dpl-cms-release: "2024.49.0"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
-  # Reference default before webmaster anchor as YAML references will not
-  # override existing keys.
-  #
-  # Normally we'd use this instead of the following 3 lines, but we
-  # need to deploy 2024.48.1 on these sites, so we have to inline it,
-  # this can be reverted when 2024.49 is released.
-  #
-  # <<: *default-release-image-source
-  #
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.48.1"
-  moduletest-dpl-cms-release: "2024.48.1"
+  <<: *default-release-image-source
+  moduletest-dpl-cms-release: "2024.49.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
Update editor and moduletest sites to 2024.49.0.

Also remove the hackery needed in the last deployment to get 2024.48.1 out on webmaster-with-defaults sites.