### PR TITLE
Use persistent Redis

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
@@ -73,7 +73,7 @@ services:
   redis:
     image: uselagoon/redis-6:latest
     labels:
-      lagoon.type: redis
+      lagoon.type: redis-persistent
     << : *default-user # uses the defined user from top
     environment:
       << : *default-environment


### PR DESCRIPTION
We have a theory that the reason the database is being hit hard in deployments is because when Kubernetes moves things around it implicitly clears the caches. So try with a persistent Redis cache.

