### PR TITLE
Revert "Use persistent Redis"

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
@@ -73,7 +73,7 @@ services:
   redis:
     image: uselagoon/redis-6:latest
     labels:
-      lagoon.type: redis-persistent
+      lagoon.type: redis
     << : *default-user # uses the defined user from top
     environment:
       << : *default-environment


### PR DESCRIPTION
Lagoon warns that it is not possible to change the service type after it has been deployed. Consequently we need to roll this back for now.

Reverts danskernesdigitalebibliotek/dpl-platform#545