### PR TITLE
add route to bornholms library

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -146,6 +146,8 @@ sites:
     name: "Bornholms Folkebiblioteker"
     description: "The library site for Bornholm"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApUNh71neiuKAsO3OL4jEzxnPCXt9gvl66gDRiYLnLw"
+    primary-domain: bibliotek.brk.dk
+    autogenerateRoutes: true
     <<: *default-release-image-source
   brondby:
     name: "Brøndby-Bibliotekerne"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
it adds a route to Bornholms library. They only have on `bibliotek.brk.dk`

#### Should this be tested by the reviewer and how?
It should just be read

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-271