### PR TITLE
add routes to odense library

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -649,6 +649,10 @@ sites:
     description: "The library site for Odense"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEQ6nngmgVZXTNpPzhMTvJyx4tUPjHxoLSNL/jJPaNQ0"
     plan: webmaster
+    primary-domain: www.odensebib.dk
+    secondary-domains:
+      - odensebib.dk
+    autogenerateRoutes: true
     <<: *webmaster-release-image-source
   odsherred:
     name: "Odsherred Bibliotek og Kulturhuse"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR add's the live routes for Odense to match their current setup. 
Their non-www domain redirects to their www domain. 

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-272