### PR TITLE
Wait a bit between namespaces during resource adjustments

### DIFF
--- a/infrastructure/task/scripts/adjust-resource-requests.sh
+++ b/infrastructure/task/scripts/adjust-resource-requests.sh
@@ -93,4 +93,10 @@ for NS in "${NAMESPACES[@]}"; do
       }
     ]'
   done
+
+  # Adjusting resources may cause a deployment to be relocated within the
+  # cluster. This will flush all in-memory caches. Wait a bit between
+  # each namespace to the site to settle before proceeding to next one.
+  # This may avoid cache stampedes.
+  sleep 15
 done


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Add 15 seconds of wait between resource requests. 

With ~100 sites this will add a total of ~25 minute delay for the deployment process. It is hard to tell whether that is enough.

It wold be optimal if we could either 

1. Warm the caches site by site manually - e.g. by running `drush cr` or curl'ing `/` or `health`
2. Avoid flushing the cache during resource request adjustments e.g. by having a persistent cache or by moving the cache away form each site
