### PR TITLE
Increase size of NGINX persistent storage to 10Gi

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/web/sites/default/files/ # define where the persistent storage should be mounted too
+      lagoon.persistent.size: 10Gi
     environment:
       << : *default-environment # loads the defined environment variables from the top
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Increase size of NGINX persistent storage to 10Gi.

This is the size limit currently set by the largest library site. Make this the default for all sites.

We currently do not have a good way to set individual size limits per site. This has created a suboptimal workflow where the site in question has to be updated manually after each workflow for the deployment to complete.

We could introduce a way to control this per site in sites.yaml but it would not provide much value. We pay for storage used - not reserved. Consequently increasing the limit for all sites should not increase costs considerably until it is actually used.

All this in mind we increase the size of the the persistent storage for the Lagoon default of 5Gb to 10Gb.
https://docs.lagoon.sh/concepts-basics/docker-compose-yml/#persistent-storage


We only need to apply this to one service. We intentionally choose the nginx one as this is the one currently bumped on one library site. Kubernetes will complain if we to try decrease the limit for attached storage. This will occur if we apply this setting to other services.

#### Should this be tested by the reviewer and how?

As I see it it is pretty hard to review.

#### Any specific requests for how the PR should be reviewed?

As I see it it is pretty hard to test.

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDFDRIFT-245
