### PR TITLE
Ensure consumer passwords and secrets in projects

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -718,6 +718,32 @@ tasks:
       - sh: "[ ! -z \"{{.PROJECT_NAME}}\" ]"
         msg: "Missing PROJECT_NAME"
 
+    lagoon:project:ensure:consumer-secrets-n-passwords:
+      vars:
+        VARIABLE_SCOPE: "RUNTIME"
+        # TODO: The variable values should be generated and stored in a secret manager.
+        VARIABLE_VALUE: "foo"
+      cmds:
+      - task: lagoon:ensure:environment-variable
+        vars:
+          VARIABLE_NAME: "BNF_GRAPHQL_CONSUMER_SECRET"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+      - task: lagoon:ensure:environment-variable
+        vars:
+          VARIABLE_NAME: "BNF_GRAPHQL_CONSUMER_USER_PASSWORD"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+      - task: lagoon:ensure:environment-variable
+        vars:
+          VARIABLE_NAME: "GO_GRAPHQL_CONSUMER_SECRET"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+      - task: lagoon:ensure:environment-variable
+        vars:
+          VARIABLE_NAME: "GO_GRAPHQL_CONSUMER_USER_PASSWORD"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+      preconditions:
+      - sh: "[ ! -z \"{{.PROJECT_NAME}}\" ]"
+        msg: "Missing PROJECT_NAME"
+
     lagoon:add:cluster:
       deps: [cluster:auth]
       desc: Add a Kubernetes cluster (Lagoon Remote) to the Lagoon Core.
@@ -799,6 +825,9 @@ tasks:
           vars:
             PROJECT_NAME: "{{.PROJECT_NAME}}"
         - task: lagoon:project:ensure:azure-mail-connection-string
+          vars:
+            PROJECT_NAME: "{{.PROJECT_NAME}}"
+        - task: lagoon:project:ensure:consumer-secrets-n-passwords
           vars:
             PROJECT_NAME: "{{.PROJECT_NAME}}"
       preconditions:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -719,27 +719,35 @@ tasks:
         msg: "Missing PROJECT_NAME"
 
     lagoon:project:ensure:consumer-secrets-n-passwords:
-      vars:
-        VARIABLE_SCOPE: "RUNTIME"
-        # TODO: The variable values should be generated and stored in a secret manager.
-        VARIABLE_VALUE: "foo"
       cmds:
       - task: lagoon:ensure:environment-variable
         vars:
           VARIABLE_NAME: "BNF_GRAPHQL_CONSUMER_SECRET"
           PROJECT_NAME: "{{.PROJECT_NAME}}"
+          VARIABLE_SCOPE: "RUNTIME"
+          # TODO: The variable values should be generated and stored in a secret manager.
+          VARIABLE_VALUE: "foo"
       - task: lagoon:ensure:environment-variable
         vars:
           VARIABLE_NAME: "BNF_GRAPHQL_CONSUMER_USER_PASSWORD"
           PROJECT_NAME: "{{.PROJECT_NAME}}"
+          VARIABLE_SCOPE: "RUNTIME"
+          # TODO: The variable values should be generated and stored in a secret manager.
+          VARIABLE_VALUE: "foo"
       - task: lagoon:ensure:environment-variable
         vars:
           VARIABLE_NAME: "GO_GRAPHQL_CONSUMER_SECRET"
           PROJECT_NAME: "{{.PROJECT_NAME}}"
+          VARIABLE_SCOPE: "RUNTIME"
+          # TODO: The variable values should be generated and stored in a secret manager.
+          VARIABLE_VALUE: "foo"
       - task: lagoon:ensure:environment-variable
         vars:
           VARIABLE_NAME: "GO_GRAPHQL_CONSUMER_USER_PASSWORD"
           PROJECT_NAME: "{{.PROJECT_NAME}}"
+          VARIABLE_SCOPE: "RUNTIME"
+          # TODO: The variable values should be generated and stored in a secret manager.
+          VARIABLE_VALUE: "foo"
       preconditions:
       - sh: "[ ! -z \"{{.PROJECT_NAME}}\" ]"
         msg: "Missing PROJECT_NAME"


### PR DESCRIPTION
#### What does this PR do?
The new consumers for the BNF and the GO project need a secret and a password set in every project or else an exception will be thrown.

IMPORTANT: This is a temporary solution. Real passwords and secret should be set in the future.

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFBRA-328

#### NOTE
This has been tested on the canary site, where you can now see the variables present:
![image](https://github.com/user-attachments/assets/f4fb8d8c-1d51-42c1-8c07-cb10c87d59a2)
