### PR TITLE
Update flags to match 0.30's new flags

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -789,10 +789,10 @@ tasks:
         # - We bump the max allowed dev environments (default is 5)
         - |
             lagoon {{.COMMAND}} project \
-            --gitUrl {{.GIT_URL}} \
-            --openshift 1 \
-            --productionEnvironment {{.production_branch}} \
-            --developmentEnvironmentsLimit 25 \
+            --git-url {{.GIT_URL}} \
+            --deploytarget 1 \
+            --production-environment {{.production_branch}} \
+            --development-environments-limit 25 \
             --branches "^({{ .BRANCHES }})$" \
             --project {{.PROJECT_NAME}}
         - task: lagoon:project:ensure:github-registry-credentials


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Lagoon CLI had it's flags updated with version 0.30 (we are running 0.31) and these flags haven't been updated, when we updated to 0.31 here  https://github.com/danskernesdigitalebibliotek/dpl-platform/pull/523. 

Here's the docs describing the update: https://dev.to/uselagoon/upcoming-lagoon-cli-release-v0300-theres-a-lot-of-changes-13d8

#### Should this be tested by the reviewer and how?
This should be tested by firstly updating the dplsh image to the newest one. 
Then run `SITE=canary site:full-sync` It should now work. 

#### Any specific requests for how the PR should be reviewed?
Read it and test it

#### What are the relevant tickets?
[DDFBRA-328](https://reload.atlassian.net/browse/DDFBRA-328)

[DDFBRA-328]: https://reload.atlassian.net/browse/DDFBRA-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ