### PR TITLE
Stabilize moduletest environment synchronization for webmaster sites

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,7 +1136,7 @@ tasks:
         TARGET_PROJECT: "{{.TARGET_PROJECT}}"
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --info=progress2"
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,7 +1136,8 @@ tasks:
         TARGET_PROJECT: "{{.TARGET_PROJECT}}"
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; drush sql-drop -y @self; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db; exit;"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; exit;"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db; exit;"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 
     sites:webmaster:reset-moduletest:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,7 +1136,7 @@ tasks:
         TARGET_PROJECT: "{{.TARGET_PROJECT}}"
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded --info=progress2"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded"
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,8 +1136,8 @@ tasks:
         TARGET_PROJECT: "{{.TARGET_PROJECT}}"
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete; exit;"
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db; exit;"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 
     sites:webmaster:reset-moduletest:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1137,7 +1137,7 @@ tasks:
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded"
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y; drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 
     sites:webmaster:reset-moduletest:

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,7 +1136,7 @@ tasks:
         TARGET_PROJECT: "{{.TARGET_PROJECT}}"
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --info=progress2"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded --info=progress2"
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1137,7 +1137,7 @@ tasks:
         TARGET_ENV: "{{.TARGET_ENV}}"
       cmds:
         - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush -y rsync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded --info=progress2"
-        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y @self && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
+        - lagoon ssh --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} -C "drush sql-drop -y && drush -y sql-sync @lagoon.{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} @self --create-db"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
 
     sites:webmaster:reset-moduletest:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Stabilize the synchronization process from main to module test environments for webmaster sites.

Practice shows there have been a number of problems with the synchronization process. This primarily seems to be caused by idle timeouts in the SSH connection to Lagoon combined with large amount of files which needs to be transferred causing the process to stop. This is combined with the error handling which in the current setup just means that we continue with the next site.

To address this this PR does three things:

1. Split the process into individual task/`lagoon ssh` commands to limit the scope
2. Exclude generated files form the synchronization process to reduce the amount of data that needs to be synchronized
3. Change error handling to abort execution if commands fail.

#### Should this be tested by the reviewer and how?

Try running the process for a webmaster site e.g. `PROJECT=customizable-canary task sites:webmaster:reset-moduletest`

#### Any specific requests for how the PR should be reviewed?

I recommend going through the PR commit by commit.
