### PR TITLE
display dplsh version on start up

### DIFF
--- a/tools/dplsh/dplsh.sh
+++ b/tools/dplsh/dplsh.sh
@@ -223,7 +223,7 @@ if [[ -f "${HOME}/.gitconfig" ]] ; then
     GITCONFIG+=(-v "${HOME}/.gitconfig:/opt/.gitconfig-host:ro")
 fi
 
-VERSION=$(docker inspect $CONTAINER_IMAGE | jq -r '.[0].Config.Labels["org.opencontainers.image.version"]')
+VERSION=$(docker inspect "$CONTAINER_IMAGE" | jq -r '.[0].Config.Labels["org.opencontainers.image.version"]')
 if [ -n "$VERSION" ]; then
   echo
   echo "DPLSH VERSION: $VERSION"

--- a/tools/dplsh/dplsh.sh
+++ b/tools/dplsh/dplsh.sh
@@ -223,6 +223,13 @@ if [[ -f "${HOME}/.gitconfig" ]] ; then
     GITCONFIG+=(-v "${HOME}/.gitconfig:/opt/.gitconfig-host:ro")
 fi
 
+VERSION=$(docker inspect $CONTAINER_IMAGE | jq -r '.[0].Config.Labels["org.opencontainers.image.version"]')
+if [ -n "$VERSION" ]; then
+  echo
+  echo "DPLSH VERSION: $VERSION"
+  echo
+fi
+
 docker run --hostname=dplsh \
     --rm \
     "${ADDITIONAL_ARGS[@]}" \


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Shows dplsh's version on start up. This will make it easier for us to know which version we are running and enable troubleshooting
![image](https://github.com/user-attachments/assets/8297761e-e197-4674-b04f-11d770fb0c57)


#### Should this be tested by the reviewer and how?
Please do, simply restart the shell 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
