### PR TITLE
remove secondary domain, which holbaek doesn't use

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -437,8 +437,6 @@ sites:
     description: "The library site for Holbæk"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL6uSbRiMzeDVejoPx5+YlAPCHebnY0XwF/zDd3YZtQ+"
     primary-domain: bibliotek.holbaek.dk
-    secondary-domains:
-      - www.bibliotek.holbaek.dk
     autogenerateRoutes: true
     <<: *default-release-image-source
   holstebro:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It removes holbaeks secondary domain which they are not using. 
It has been run. 

#### Should this be tested by the reviewer and how?
Just read it

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?search=go%20live%20holb&selectedIssue=DDFDRIFT-250