### PR TITLE
Deploy release 2025.3.0 on staging

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -470,7 +470,6 @@ tasks:
             --lagoon {{.platform_env}}
         - lagoon config default --lagoon {{.platform_env}}
         - lagoon login
-        - lagoon whoami
       preconditions:
       - sh: "[ ! -z {{.ssh_loadbalancer_ip}} ]"
         msg: "Could not determine IP of the ssh-endpoint for Lagoon. The Kubernetes lagoon-core/lagoon-core-ssh service may not have been provisioned yet."

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -792,6 +792,11 @@ sites:
     name: "Solrød Bibliotek og Kulturhus"
     description: "The library site for Solrød"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF1GwZ4r8QZ7Vebdqiz/mtkifrLU+ZSvlAJshdXjCh5J"
+    <<: *default-release-image-source
+  solrod2:
+    name: "Solrød Bibliotek og Kulturhus"
+    description: "The library site for Solrød"
+    deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII3HmqAMg/J80EG9JvAYAZZLn8xGOLsqDOG5eugUuOS1"
     primary-domain: solbib.dk
     secondary-domains:
       - www.solbib.dk

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -789,6 +789,7 @@ sites:
     autogenerateRoutes: true
     <<: *default-release-image-source
   solrod:
+    #This site is dead due to the following problem: https://reload.zulipchat.com/#narrow/channel/240325-DDF/topic/Hasteopgave.2013.2F01.2F25
     name: "Solrød Bibliotek og Kulturhus"
     description: "The library site for Solrød"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF1GwZ4r8QZ7Vebdqiz/mtkifrLU+ZSvlAJshdXjCh5J"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -47,7 +47,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.3.1"
+    dpl-cms-release: "2025.3.2"
     plan: webmaster
     moduletest-dpl-cms-release: "2024.50.0"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -47,7 +47,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.3.0"
+    dpl-cms-release: "2025.3.1"
     plan: webmaster
     moduletest-dpl-cms-release: "2024.50.0"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -47,7 +47,7 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.2.0"
+    dpl-cms-release: "2025.3.0"
     plan: webmaster
     moduletest-dpl-cms-release: "2024.50.0"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2025.3.0 on staging.

This has already been applied.

Note that this PR also includes a few other changes that are needed before the update can be deployed. This includes:

- Adding a new site for Solrød because a table for the current database has been corrupted
- Removing a call to `lagoon whoami` which currently fails