### PR TITLE
Release week 3

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -5,6 +5,7 @@ x-defaults: &default-release-image-source
   dpl-cms-release: "2025.3.2"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
+  # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.50.0"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -4,6 +4,7 @@ x-defaults: &default-release-image-source
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.3.2"
 x-webmaster: &webmaster-release-image-source
+  # This is the default release plan for webmasters. There's currently no webmasters on it.
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.50.0"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -20,6 +20,12 @@ x-webmaster-postponed-until-2025-01-06: &webmaster-postponed-until-2025-01-06
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.47.2"
   moduletest-dpl-cms-release: "2024.50.0"
+x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
+  #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
+  dpl-cms-release: "2024.50.0"
+  moduletest-dpl-cms-release: "2025.3.2"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -9,8 +9,6 @@ x-webmaster: &webmaster-release-image-source
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.50.0"
   moduletest-dpl-cms-release: "2025.3.2"
-# Some sites on the webmaster plan wish to track the same release as
-# sites do per default in dpl-cms-release.
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -13,13 +13,6 @@ x-webmaster: &webmaster-release-image-source
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
   <<: *default-release-image-source
   moduletest-dpl-cms-release: "2024.50.0"
-# Postponed 2024.12.12, they don't want 2024.49.0 on production,
-# postponing it to 2024.50.0.
-x-webmaster-postponed-until-2025-01-06: &webmaster-postponed-until-2025-01-06
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.47.2"
-  moduletest-dpl-cms-release: "2024.50.0"
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.50.0"
+  dpl-cms-release: "2025.3.2"
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -6,8 +6,8 @@ x-defaults: &default-release-image-source
 x-webmaster: &webmaster-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.49.0"
-  moduletest-dpl-cms-release: "2024.50.0"
+  dpl-cms-release: "2024.50.0"
+  moduletest-dpl-cms-release: "2025.3.2"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
 x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -10,9 +10,6 @@ x-webmaster: &webmaster-release-image-source
   moduletest-dpl-cms-release: "2025.3.2"
 # Some sites on the webmaster plan wish to track the same release as
 # sites do per default in dpl-cms-release.
-x-webmaster-with-defaults: &webmaster-with-defaults-release-image-source
-  <<: *default-release-image-source
-  moduletest-dpl-cms-release: "2024.50.0"
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
@@ -56,14 +53,14 @@ sites:
     importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
-    <<: *webmaster-with-defaults-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   bibliotek-test:
     name: "Bibliotekstest"
     description: "Et site hvor bibliotekerne kan teste"
     importTranslationsCron: "0 * * * *"
     plan: webmaster
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   # BNF site.
   bnf:
     name: "Bibliotekernes Nationale Formidling"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -99,7 +99,7 @@ sites:
       - aalborgbibliotekerne.dk
     autogenerateRoutes: "redirect"
     plan: webmaster
-    <<: *webmaster-with-defaults-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
@@ -109,7 +109,7 @@ sites:
     secondary-domains:
       - aakb.dk
     autogenerateRoutes: true
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   aero:
     name: "Ærø Folkebibliotek"
     description: "The library site for Ærø"
@@ -128,7 +128,7 @@ sites:
       - www.albertslundbibliotek.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   allerod:
     name: "Allerød Biblioteker"
     description: "The library site for Allerød"
@@ -152,7 +152,7 @@ sites:
       - www.bib.ballerup.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   billund:
     name: "Billund Bibliotekerne og Borgerservice"
     description: "The main library site for Billund"
@@ -249,7 +249,7 @@ sites:
       - "faxebibliotek.dk"
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   fredensborg:
     name: "Fredensborg Bibliotekerne"
     description: "The library site for Fredensborg"
@@ -410,7 +410,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"
@@ -534,7 +534,7 @@ sites:
       - varnish.main.kobenhavn.dplplat01.dpl.reload.dk
     plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   koge:
     name: "KøgeBibliotekerne"
     description: "The library site for Køge"
@@ -679,7 +679,7 @@ sites:
     secondary-domains:
       - odensebib.dk
     autogenerateRoutes: true
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   odsherred:
     name: "Odsherred Bibliotek og Kulturhuse"
     description: "The library site for Odsherred"
@@ -745,7 +745,7 @@ sites:
     secondary-domains:
       - roskildebib.dk
     autogenerateRoutes: true
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   rudersdal:
     name: "Rudersdal Bibliotekerne"
     description: "The library site for Rudersdal"
@@ -775,7 +775,7 @@ sites:
       - www.silkeborgbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-with-defaults-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"
@@ -818,7 +818,7 @@ sites:
       - www.biblioteket.sonderborg.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-release-image-source
+    <<: *webmasters-on-weekly-release-cycle
   soro:
     name: "Sorø Bibliotek"
     description: "The library site for Sorø"
@@ -855,7 +855,7 @@ sites:
       - dcbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   svendborg:
     name: "Svendborg Bibliotek"
     description: "The library site for Svendborg"
@@ -879,7 +879,7 @@ sites:
     secondary-domains:
       - www.taarnbybib.dk
     autogenerateRoutes: true
-    <<: *webmaster-postponed-until-2025-01-06
+    <<: *webmasters-on-weekly-release-cycle
   thisted:
     name: "Biblioteket i Thy"
     description: "The library site for Thisted"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR does 5 things
- It releases 2025.3.2 to editors
- Releases 2024.50.0 to webmasters production
- Releases 2025.3.2 to webmaster moduletests
- Removes unused anchors: `postponed-until` as well as `webmasters on default release cycle'
- Introduces the new weekly release cycle as requested by the libraries: https://reload.atlassian.net/browse/DDFDRIFT-277

#### Should this be tested by the reviewer and how?
This should be read thoroughly. Do not apply 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-283