### PR TITLE
Add task to restore database - potentially across projects/environments

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1123,6 +1123,27 @@ tasks:
       preconditions:
       - *require_site
 
+    site:backup:restore:db:
+      desc: Restore the database backup for a site/environment to the same or another site/environment.
+      deps: [lagoon:cli:config]
+      vars:
+        PROJECT: "{{.PROJECT}}"
+        PROJECT_ENV: '{{.PROJECT_ENV | default "main" }}'
+        SOURCE_PROJECT: "{{.SOURCE_PROJECT | default .PROJECT }}"
+        SOURCE_ENV: "{{.SOURCE_ENV | default .PROJECT_ENV }}"
+        TARGET_PROJECT: "{{.TARGET_PROJECT | default .PROJECT}}"
+        TARGET_ENV: "{{.TARGET_ENV | default .PROJECT_ENV }}"
+        TARGET_NAMESPACE: "{{.TARGET_PROJECT}}-{{.TARGET_ENV}}"
+        LOCAL_BACKUP_DESTINATION: "/tmp/{{.SOURCE_PROJECT}}-mariadb-backup.tar.gz"
+        REMOTE_BACKUP_DESTINATION: "/tmp/{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}-mariadb-prebackuppod.mariadb.sql"
+      prompt:
+        - Restore latest database backup from {{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} to {{.TARGET_PROJECT}}-{{.TARGET_ENV}}
+      cmds:
+        - LAGOON_PROJECT={{.SOURCE_PROJECT}} BACKUP_TYPE=mariadb BACKUP_DESTINATION={{.LOCAL_BACKUP_DESTINATION}} ./task/scripts/lagoon-get-backup.sh
+        - kubectl cp -n {{.TARGET_NAMESPACE}} $(tar -xvzf {{.LOCAL_BACKUP_DESTINATION}}) $(kubectl -n {{.TARGET_NAMESPACE}} get pod -l app.kubernetes.io/instance=cli -o jsonpath="{.items[0].metadata.name}"):{{.REMOTE_BACKUP_DESTINATION}}
+        - kubectl exec -n {{.TARGET_NAMESPACE}} deployment/cli -- bash -c "echo Verifying file && test -s {{.REMOTE_BACKUP_DESTINATION}} || (echo {{.REMOTE_BACKUP_DESTINATION}} is missing or empty && exit 1) && echo Dropping database && drush sql-drop -y && echo Importing backup && drush sql:query --file={{.REMOTE_BACKUP_DESTINATION}} && echo Deleting backup && rm {{.REMOTE_BACKUP_DESTINATION}}"
+        - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force
+
     site:environment:sync:
       desc: |
         Synchonizes all file and database tables from environment

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1136,10 +1136,11 @@ tasks:
         TARGET_NAMESPACE: "{{.TARGET_PROJECT}}-{{.TARGET_ENV}}"
         LOCAL_BACKUP_DESTINATION: "/tmp/{{.SOURCE_PROJECT}}-mariadb-backup.tar.gz"
         REMOTE_BACKUP_DESTINATION: "/tmp/{{.SOURCE_PROJECT}}-{{.SOURCE_ENV}}-mariadb-prebackuppod.mariadb.sql"
+        BACKUP_ENTRY: '{{.BACKUP_ENTRY | default "1" }}'
       prompt:
-        - Restore latest database backup from {{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} to {{.TARGET_PROJECT}}-{{.TARGET_ENV}}
+        - Restore {{.BACKUP_ENTRY}}. most recent database backup from {{.SOURCE_PROJECT}}-{{.SOURCE_ENV}} to {{.TARGET_PROJECT}}-{{.TARGET_ENV}}
       cmds:
-        - LAGOON_PROJECT={{.SOURCE_PROJECT}} BACKUP_TYPE=mariadb BACKUP_DESTINATION={{.LOCAL_BACKUP_DESTINATION}} ./task/scripts/lagoon-get-backup.sh
+        - LAGOON_PROJECT={{.SOURCE_PROJECT}} BACKUP_TYPE=mariadb BACKUP_ENTRY={{.BACKUP_ENTRY}} BACKUP_DESTINATION={{.LOCAL_BACKUP_DESTINATION}} ./task/scripts/lagoon-get-backup.sh
         - kubectl cp -n {{.TARGET_NAMESPACE}} $(tar -xvzf {{.LOCAL_BACKUP_DESTINATION}}) $(kubectl -n {{.TARGET_NAMESPACE}} get pod -l app.kubernetes.io/instance=cli -o jsonpath="{.items[0].metadata.name}"):{{.REMOTE_BACKUP_DESTINATION}}
         - kubectl exec -n {{.TARGET_NAMESPACE}} deployment/cli -- bash -c "echo Verifying file && test -s {{.REMOTE_BACKUP_DESTINATION}} || (echo {{.REMOTE_BACKUP_DESTINATION}} is missing or empty && exit 1) && echo Dropping database && drush sql-drop -y && echo Importing backup && drush sql:query --file={{.REMOTE_BACKUP_DESTINATION}} && echo Deleting backup && rm {{.REMOTE_BACKUP_DESTINATION}}"
         - lagoon deploy latest --project {{.TARGET_PROJECT}} --environment {{.TARGET_ENV}} --force

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1131,7 +1131,7 @@ tasks:
         PROJECT_ENV: '{{.PROJECT_ENV | default "main" }}'
         SOURCE_PROJECT: "{{.SOURCE_PROJECT | default .PROJECT }}"
         SOURCE_ENV: "{{.SOURCE_ENV | default .PROJECT_ENV }}"
-        TARGET_PROJECT: "{{.TARGET_PROJECT | default .PROJECT}}"
+        TARGET_PROJECT: "{{.TARGET_PROJECT | default .SOURCE_PROJECT }}"
         TARGET_ENV: "{{.TARGET_ENV | default .PROJECT_ENV }}"
         TARGET_NAMESPACE: "{{.TARGET_PROJECT}}-{{.TARGET_ENV}}"
         LOCAL_BACKUP_DESTINATION: "/tmp/{{.SOURCE_PROJECT}}-mariadb-backup.tar.gz"

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -10,7 +10,7 @@ if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}
 fi
 
 BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --output-json);
-BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data[] | select(.source == \"${BACKUP_TYPE}\") | .backupid" | head -n 1);
+BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data | map(select(.source == \"${BACKUP_TYPE}\")) | nth(0) | .backupid");
 BACKUP_RESULT="Error";
 echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
 # Wait a while we wait for the backup to become available.

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -11,16 +11,17 @@ fi
 
 BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --output-json);
 BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data[] | select(.source == \"${BACKUP_TYPE}\") | .backupid" | head -n 1);
-BACKUP_URL="Error";
+BACKUP_RESULT="Error";
 echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
 # Wait a while we wait for the backup to become available.
 # It must be retrieved before it can be downloaded.
-while [[ $BACKUP_URL == "Error"* ]]; do
+while [[ $BACKUP_RESULT == "Error"* ]]; do
   echo -n ".";
   eval "lagoon retrieve backup -p \"${LAGOON_PROJECT}\" -e \"${LAGOON_ENVIRONMENT}\" --backup-id \"${BACKUP_ID}\" --force &> /dev/null" || true;
   # This will return an message in the format "Error: [error message]" if the
   # backup is not available for download yet.
-  BACKUP_URL=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" 2>/dev/null) || true;
+  BACKUP_RESULT=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" --output-json 2>/dev/null) || true;
+  BACKUP_URL=$(echo "$BACKUP_RESULT" | jq -r ".result") || true
 done;
 echo -e "\nDownloading backup from ${BACKUP_URL} to ${BACKUP_DESTINATION}\n\n";
 curl -o "${BACKUP_DESTINATION}" "${BACKUP_URL}";

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -23,7 +23,7 @@ while [[ $BACKUP_RESULT == "Error"* ]]; do
   eval "lagoon retrieve backup -p \"${LAGOON_PROJECT}\" -e \"${LAGOON_ENVIRONMENT}\" --backup-id \"${BACKUP_ID}\" --force &> /dev/null" || true;
   # This will return an message in the format "Error: [error message]" if the
   # backup is not available for download yet.
-  BACKUP_RESULT=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" --output-json 2>/dev/null) || true;
+  BACKUP_RESULT=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" --output-json 2>&1) || true;
   BACKUP_URL=$(echo "$BACKUP_RESULT" | jq -r ".result") || true
 done;
 echo -e "\nDownloading backup from ${BACKUP_URL} to ${BACKUP_DESTINATION}\n\n";

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -24,7 +24,7 @@ while [[ $BACKUP_RESULT == "Error"* ]]; do
   # This will return an message in the format "Error: [error message]" if the
   # backup is not available for download yet.
   BACKUP_RESULT=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" --output-json 2>&1) || true;
-  BACKUP_URL=$(echo "$BACKUP_RESULT" | jq -r ".result") || true
 done;
+BACKUP_URL=$(echo "$BACKUP_RESULT" | jq -r ".result")
 echo -e "\nDownloading backup from ${BACKUP_URL} to ${BACKUP_DESTINATION}\n\n";
 curl -o "${BACKUP_DESTINATION}" "${BACKUP_URL}";

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Restore and download files from a Lagoon backup.
+set -eo pipefail
+
+LAGOON_ENVIRONMENT="${LAGOON_ENVIRONMENT:-main}"
+
+if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}" ]]; then
+	echo "usage: LAGOON_PROJECT=<LAGOON_PROJECT> BACKUP_TYPE=<BACKUP_TYPE> BACKUP_DESTINATION=<BACKUP_DESTINATION> $0" >&2
+	exit 1
+fi
+
+BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --output-json);
+BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data[] | select(.source == \"${BACKUP_TYPE}\") | .backupid" | head -n 1);
+BACKUP_URL="Error";
+echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
+# Wait a while we wait for the backup to become available.
+# It must be retrieved before it can be downloaded.
+while [[ $BACKUP_URL == "Error"* ]]; do
+  echo -n ".";
+  eval "lagoon retrieve backup -p \"${LAGOON_PROJECT}\" -e \"${LAGOON_ENVIRONMENT}\" --backup-id \"${BACKUP_ID}\" --force &> /dev/null" || true;
+  # This will return an message in the format "Error: [error message]" if the
+  # backup is not available for download yet.
+  BACKUP_URL=$(lagoon get backup -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --backup-id "${BACKUP_ID}" 2>/dev/null) || true;
+done;
+echo -e "\nDownloading backup from ${BACKUP_URL} to ${BACKUP_DESTINATION}\n\n";
+curl -o "${BACKUP_DESTINATION}" "${BACKUP_URL}";

--- a/infrastructure/task/scripts/lagoon-get-backup.sh
+++ b/infrastructure/task/scripts/lagoon-get-backup.sh
@@ -3,6 +3,9 @@
 set -eo pipefail
 
 LAGOON_ENVIRONMENT="${LAGOON_ENVIRONMENT:-main}"
+# The entry in the list of backups for the provided type to retrieve for the
+# given backup type. 1 is the most recent.
+BACKUP_ENTRY_INDEX=$((${BACKUP_ENTRY:-1}-1));
 
 if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}" ]]; then
 	echo "usage: LAGOON_PROJECT=<LAGOON_PROJECT> BACKUP_TYPE=<BACKUP_TYPE> BACKUP_DESTINATION=<BACKUP_DESTINATION> $0" >&2
@@ -10,9 +13,9 @@ if [[ -z "${LAGOON_PROJECT}" || -z "${BACKUP_TYPE}" || -z "${BACKUP_DESTINATION}
 fi
 
 BACKUPS=$(lagoon list backups -p "${LAGOON_PROJECT}" -e "${LAGOON_ENVIRONMENT}" --output-json);
-BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data | map(select(.source == \"${BACKUP_TYPE}\")) | nth(0) | .backupid");
+BACKUP_ID=$(echo "$BACKUPS" | jq -r ".data | map(select(.source == \"${BACKUP_TYPE}\")) | nth(${BACKUP_ENTRY_INDEX}) | .backupid");
 BACKUP_RESULT="Error";
-echo -e "\nRetrieving ${BACKUP_TYPE} backup from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
+echo -e "\nRetrieving ${BACKUP_ENTRY}. ${BACKUP_TYPE} backup with id ${BACKUP_ID} from ${LAGOON_ENVIRONMENT} environment of ${LAGOON_PROJECT} project \n\n";
 # Wait a while we wait for the backup to become available.
 # It must be retrieved before it can be downloaded.
 while [[ $BACKUP_RESULT == "Error"* ]]; do


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Add task to restore database - potentially across projects/environments. This scripts [the process described in the documentation](https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/retrieve-restore-backup/?h=retrie#step-1-downloading-the-backup).



#### Should this be tested by the reviewer and how?

1. Create a PR environment for `dpl-cms`.
2. Try to synchronize the database of a site into this environment. 

My results:

```
dplsh:/home/dplsh/host_mount$ SOURCE_PROJECT=kobenhavn TARGET_PROJECT=dpl-cms TARGET_ENV=pr-1956 task site:backup:restore:db
task: Task "_infra:terraform:init" is up to date
task: Task "cluster:auth" is up to date
task: Task "_infra:terraform:init" is up to date
task: Task "cluster:auth" is up to date
task: Task "lagoon:cli:config" is up to date
Restore latest database backup from kobenhavn-main to dpl-cms-pr-1956 [y/N]: y
task: [site:backup:restore:db] LAGOON_PROJECT=kobenhavn BACKUP_TYPE=mariadb BACKUP_DESTINATION=/tmp/kobenhavn-mariadb-backup.tar.gz ./task/scripts/lagoon-get-backup.sh

Retrieving mariadb backup from main environment of kobenhavn project


.
Downloading backup from https://backup-storage.lagoon.dplplat01.dpl.reload.dk/restore/backup-kobenhavn-main-kobenhavn-main-mariadb-prebackuppod.mariadb.sql-2025-01-20T11%3A28%3A39Z.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6nu3WdO8gb-j1tVNoEykhg%2F20250120%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250120T214308Z&X-Amz-Expires=300&X-Amz-Signature=f30580d4c102503d7c5c610d183e92cd00927b05427dde36a0e5e724c0da4836&X-Amz-SignedHeaders=host to /tmp/kobenhavn-mariadb-backup.tar.gz


  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24.1M  100 24.1M    0     0  14.9M      0  0:00:01  0:00:01 --:--:-- 14.9M
task: [site:backup:restore:db] kubectl cp -n dpl-cms-pr-1956 $(tar -xvzf /tmp/kobenhavn-mariadb-backup.tar.gz) $(kubectl -n dpl-cms-pr-1956 get pod -l app.kubernetes.io/instance=cli -o jsonpath="{.items[0].metadata.name}"):/tmp/kobenhavn-main-mariadb-prebackuppod.mariadb.sql
task: [site:backup:restore:db] kubectl exec -n dpl-cms-pr-1956 deployment/cli -- bash -c "echo Verifying file && test -s /tmp/kobenhavn-main-mariadb-prebackuppod.mariadb.sql || (echo /tmp/kobenhavn-main-mariadb-prebackuppod.mariadb.sql is missing or empty && exit 1) && echo Dropping database && drush sql-drop -y && echo Importing backup && drush sql:query --file=/tmp/kobenhavn-main-mariadb-prebackuppod.mariadb.sql && echo Deleting backup && rm /tmp/kobenhavn-main-mariadb-prebackuppod.mariadb.sql"
Verifying file
Dropping database

 // Do you really want to drop all tables in the database
 // dpl-cms-pr-1956_Ao2nt?: yes.

Importing backup

Deleting backup
task: [site:backup:restore:db] lagoon deploy latest --project dpl-cms --environment pr-1956 --force
Result: lagoon-build-unayel
```

#### Any specific requests for how the PR should be reviewed?

I recommend going commit by commit.

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDFDRIFT-287
