### PR TITLE
add autogenerate (deafult) routes to cms-school

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -50,9 +50,9 @@ sites:
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
-    importTranslationsCron: "0 * * * *"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
+    autogenerateRoutes: true
     <<: *webmasters-on-weekly-release-cycle
   bibliotek-test:
     name: "Bibliotekstest"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It restores CMS-school

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?
Just read it - it has been run already 

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-288