### PR TITLE
Updating staging to test release 2025.4.0

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,9 +43,9 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.3.2"
+    dpl-cms-release: "2025.4.0"
     plan: webmaster
-    moduletest-dpl-cms-release: "2024.50.0"
+    moduletest-dpl-cms-release: "2025.4.0"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
#### What does this PR do?
Updates staging to test release 2025.4.0

#### Should this be tested by the reviewer and how?
Look at it. :)
**Important**: I noticed that the module test version of the staging site were behind the "master" version. Is that a coincidence or do we have to do any further actions - or skip updating the module test version?

