### PR TITLE
Deploy release 2025.4.0

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,20 +2,20 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.3.2"
+  dpl-cms-release: "2025.4.0"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2024.50.0"
-  moduletest-dpl-cms-release: "2025.3.2"
+  moduletest-dpl-cms-release: "2025.4.0"
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2024.50.0"
-  moduletest-dpl-cms-release: "2025.3.2"
+  dpl-cms-release: "2025.3.2"
+  moduletest-dpl-cms-release: "2025.4.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This updates most sites to the latest release 2025.4.0.

Moduletest sites for webmasters are also updated to the latest release while webmaster sites on the weekly schedule are updated to the second most recent release, 2024.3.2.

This has *not* been applied yet.

#### Any specific requests for how the PR should be reviewed?

Read it through.
