### PR TITLE
Do not set task directory when ensuring project

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1102,7 +1102,6 @@ tasks:
         Ensures a lagoon project is set up and configured correctly for a
         given site as specified by sites.yaml
       deps: [lagoon:cli:config]
-      dir: "{{.dir_env}}"
       silent: true
       vars:
         GIT_URL: "git@github.com:danishpubliclibraries/env-{{.SITE}}.git"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Do not set task directory when ensuring project

On OSX even within the DPLSH we sometimes see the following error when running deployments: No Taskfile found at "/home/dplsh/host_mount/environments/dplplat01"

There is no Taskfile in the provided directory and it is not intentional that we execute tasks from this directory either.

For unknown reasons we currently set the default directory to .dir_env which is /home/dplsh/host_mount/environments/dplplat01. This should not be necessary.

The only command which references a specific part of the file system is the SITE_PLAN var. This already uses .dir_env.

Consequently we remove it.

#### Should this be tested by the reviewer and how?

Try to deploy e.g. `SITE=canary task site:full-sync`. It should run without problems.

I have tried to use this during the release of `2025.8.1`. The problem did not occur.