### PR TITLE
Release week 6

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -8,7 +8,7 @@ lagoon-build-deploy:
     - "--harbor-username=admin"
     - "--harbor-password=$HARBOR_ADMIN_PASS"
     - "--enable-qos"
-    - "--qos-max-builds=4"
+    - "--qos-max-builds=8"
   rabbitMQUsername: "lagoon"
   rabbitMQPassword: "$RABBITMQ_PASS"
   rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.5.1"
+  dpl-cms-release: "2025.6.0"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -51,9 +51,9 @@ sites:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
-    dpl-cms-release: "2025.4.0"
+    dpl-cms-release: "2025.6.0"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.5.1"
+    moduletest-dpl-cms-release: "2025.6.0"
     autogenerateRoutes: true
     <<: *webmasters-on-weekly-release-cycle
   bibliotek-test:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.4.0"
-  moduletest-dpl-cms-release: "2025.5.1"
+  dpl-cms-release: "2025.5.1"
+  moduletest-dpl-cms-release: "2025.6.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -35,8 +35,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.4.0"
-    moduletest-dpl-cms-release: "2025.5.1"
+    dpl-cms-release: "2025.5.1"
+    moduletest-dpl-cms-release: "2025.6.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It release 2025.6.0 to: 
- editors
- webmaster moduletest

It also releases 2025.5.1:
- webmaster production 

Additionally cms-school is now tracking the newest release on both prod and moduletest

#### Should this be tested by the reviewer and how?
jsut read it 

#### Any specific requests for how the PR should be reviewed?
Just read it 

#### What are the relevant tickets?
DDFDRIFT-303