### PR TITLE
Release week 7

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -8,7 +8,7 @@ lagoon-build-deploy:
     - "--harbor-username=admin"
     - "--harbor-password=$HARBOR_ADMIN_PASS"
     - "--enable-qos"
-    - "--qos-max-builds=8"
+    - "--qos-max-builds=10"
   rabbitMQUsername: "lagoon"
   rabbitMQPassword: "$RABBITMQ_PASS"
   rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -31,9 +31,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.4.0"
+    dpl-cms-release: "2025.7.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.5.1"
+    moduletest-dpl-cms-release: "2025.7.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -16,7 +16,7 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.6.0"
   moduletest-dpl-cms-release: "2025.7.1"
-x-&webmasters-prod-stying-on-0.6: &webmasters-prod-stying-on-0.6
+x-&webmasters-prod-stying-on-5.1: &webmasters-prod-stying-on-5.1
   #Herning wants to stay on their current version on production and have the newest release on moduletest
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
@@ -412,7 +412,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-prod-stying-on-0.6
+    <<: *webmasters-prod-stying-on-5.1
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -16,8 +16,12 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.6.0"
   moduletest-dpl-cms-release: "2025.7.1"
+x-&webmasters-prod-stying-on-0.6: &webmasters-prod-stying-on-0.6
+  #Herning wants to stay on their current version on production and have the newest release on moduletest
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.5.1"
-  moduletest-dpl-cms-release: "2025.6.0"
+  moduletest-dpl-cms-release: "2025.7.1"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -408,7 +412,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-on-weekly-release-cycle
+    <<: *webmasters-prod-stying-on-0.6
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -41,8 +41,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.5.1"
-    moduletest-dpl-cms-release: "2025.6.0"
+    dpl-cms-release: "2025.6.0"
+    moduletest-dpl-cms-release: "2025.7.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -16,7 +16,7 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.6.0"
   moduletest-dpl-cms-release: "2025.7.1"
-x-&webmasters-prod-stying-on-5.1: &webmasters-prod-stying-on-5.1
+x-&webmasters-prod-stying-on-5-1: &webmasters-prod-stying-on-5-1
   #Herning wants to stay on their current version on production and have the newest release on moduletest
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
@@ -412,7 +412,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-prod-stying-on-5.1
+    <<: *webmasters-prod-stying-on-5-1
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -57,9 +57,9 @@ sites:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
-    dpl-cms-release: "2025.6.0"
+    dpl-cms-release: "2025.7.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.6.0"
+    moduletest-dpl-cms-release: "2025.7.1"
     autogenerateRoutes: true
     <<: *webmasters-on-weekly-release-cycle
   bibliotek-test:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.6.0"
+  dpl-cms-release: "2025.7.1"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,6 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
+  dpl-cms-release: "2025.6.0"
+  moduletest-dpl-cms-release: "2025.7.1"
   dpl-cms-release: "2025.5.1"
   moduletest-dpl-cms-release: "2025.6.0"
 sites:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It releases the newest version to: 
- editor production sites
- webmaster moduletest sites

Webmaster production sites are getting last weeks release on their production sites. 

Herning wants to stay on 5.1 on their production site. 

Deploy 10 sites at a time 

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?
Just read it 

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-305