### PR TITLE
Deploy release 2025.8.1 to staging

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,9 +43,9 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.8.0"
+    dpl-cms-release: "2025.8.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.8.0"
+    moduletest-dpl-cms-release: "2025.8.1"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2025.8.1 to staging. This has already been applied.

The deployment required an extra fix to `sites.yaml` that needs to be merged to get deployments working.

#### Any specific requests for how the PR should be reviewed?

Just read it.
