### PR TITLE
release 9.0 to moduletests and editors and 8.1 to WM prod

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -25,9 +25,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.7.1"
+    dpl-cms-release: "2025.8.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.7.1"
+    moduletest-dpl-cms-release: "2025.9.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -35,8 +35,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.6.0"
-    moduletest-dpl-cms-release: "2025.7.1"
+    dpl-cms-release: "2025.8.1"
+    moduletest-dpl-cms-release: "2025.9.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"
@@ -51,9 +51,9 @@ sites:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
-    dpl-cms-release: "2025.7.1"
+    dpl-cms-release: "2025.9.0"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.7.1"
+    moduletest-dpl-cms-release: "2025.9.0"
     autogenerateRoutes: true
     <<: *webmasters-on-weekly-release-cycle
   bibliotek-test:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.8.1"
+  dpl-cms-release: "2025.9.0"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
@@ -14,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.7.2"
-  moduletest-dpl-cms-release: "2025.8.1"
+  dpl-cms-release: "2025.8.1"
+  moduletest-dpl-cms-release: "2025.9.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR releases the following versions to the following environments:
- 9.0 to editors and WM moduletest
- 8.1 to WM production

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-309