### PR TITLE
Release 2025.10.0

### DIFF
--- a/docs/runbooks/weekly-release-to-editors-and-moduletests.md
+++ b/docs/runbooks/weekly-release-to-editors-and-moduletests.md
@@ -20,10 +20,10 @@ the production environments of webmasters.
    branch for `dpl-platform` is up to date.
 2. Create a new branch from `main`.
 3. Now update `infrastructure/environments/dplplat01/sites.yaml`. The
-    'x-defaults' anchors' 'dpl-cms-release' tag should be bumped to
-    the new version. Then update the 'moduletest-dpl-cms-release' of
-    'x-webmaster' to the same version. Update the same property for
-    the 'x-webmaster-with-defaults' anchor.
+    `x-defaults` anchors' `dpl-cms-release` tag should be bumped to
+    the new version. Then update the `moduletest-dpl-cms-release` of
+    `x-webmaster` to the same version. Update the same property for
+    the `x-webmaster-with-defaults` anchor.
 4. Commit the change and push your branch to GitHub and create a pull
    request.
 5. Request a review for the change and wait for approval.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.9.0"
+  dpl-cms-release: "2025.10.0"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
@@ -14,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.8.1"
-  moduletest-dpl-cms-release: "2025.9.0"
+  dpl-cms-release: "2025.9.0"
+  moduletest-dpl-cms-release: "2025.10.0"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
Deploy release 2025.10.0 to editor libraries and moduletest envs, 2025.9.0 to the main env on webmaster libraries.

And fix quoting in runbook (which is out of date, but that's another thing).