### PR TITLE
Avoid release 2025.10.0

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -30,7 +30,7 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.10.0"
+    dpl-cms-release: "2025.11.0"
     plan: webmaster
     moduletest-dpl-cms-release: "2025.11.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
@@ -40,7 +40,7 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.10.0"
+    dpl-cms-release: "2025.11.0"
     moduletest-dpl-cms-release: "2025.11.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,7 +14,7 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.10.0"
+  dpl-cms-release: "2025.11.0"
   moduletest-dpl-cms-release: "2025.11.0"
 x-webmasters-staying-on-9.0: &webmasters-staying-on-9.0
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2025.11.0 to webmasters and canary sites. Release 2025.10.0 has a serious bug that we want to avoid.
