### PR TITLE
point to the new folder instead

### DIFF
--- a/.github/workflows/lagoon-redeploy-controller-build-release.yaml
+++ b/.github/workflows/lagoon-redeploy-controller-build-release.yaml
@@ -6,7 +6,7 @@
 on:
   pull_request:
     paths:
-      - "/infrastructure/environment/dplplat01/configuration/lagoon-redeploy-controller/**"
+      - "/infrastructure/images/lagoon-redeploy-controller/**"
       - ".github/workflows/lagoon-redeploy-controller-build-release.yaml"
     tags:
       - "lrc-*-rc"
@@ -15,7 +15,7 @@ on:
       - main
     # Limit pushes on main to only build if these files has changed.
     paths:
-      - "/infrastructure/environment/dplplat01/configuration/lagoon-redeploy-controller/**"
+      - "/infrastructure/images/lagoon-redeploy-controller/**"
       - ".github/workflows/lagoon-redeploy-controller-build-release.yaml"
     tags:
       - "lrc-*"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
We were pointing to the old folder, where the project started it's residence. 
It now lives in `infrastructure/images/lagoon-redeploy-controller`

#### Should this be tested by the reviewer and how?
Read it through

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-264