### PR TITLE
allow cli to use more memory and provision some more for it from the …

### DIFF
--- a/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
+++ b/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
@@ -14,8 +14,8 @@ spec:
     containerPolicies:
     - containerName: cli
       minAllowed:
-        cpu: 4m
-        memory: 2Mi
+        cpu: 200m
+        memory: 200Mi
       maxAllowed:
-        cpu: 150m
-        memory: 250Mi
+        cpu: 400m
+        memory: 1.1Gi

--- a/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
+++ b/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
@@ -14,8 +14,8 @@ spec:
     containerPolicies:
     - containerName: cli
       minAllowed:
-        cpu: 200m
-        memory: 200Mi
+        cpu: 4m
+        memory: 2Mi
       maxAllowed:
         cpu: 400m
         memory: 1.1Gi

--- a/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
+++ b/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
@@ -14,8 +14,8 @@ spec:
     containerPolicies:
     - containerName: cli
       minAllowed:
-        cpu: 4m
-        memory: 2Mi
+        cpu: 20m
+        memory: 300Mi
       maxAllowed:
         cpu: 400m
         memory: 1.1Gi


### PR DESCRIPTION
…get go

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It allows all production sites CLI pod to use more memory

#### Should this be tested by the reviewer and how?
Just read it - it will be applied on the next deployment when merged 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-324