### PR TITLE
allow DPL CMS and BNF pr envs more memory, so they can run their cron…

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
+++ b/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
@@ -35,7 +35,7 @@ spec:
                         memory_limit=256Mi
                         ;;
                       cli)
-                        memory_request=250Mi
+                        memory_request=100Mi
                         memory_limit=1Gi
                         ;;
                       *)

--- a/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
+++ b/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
@@ -35,8 +35,8 @@ spec:
                         memory_limit=256Mi
                         ;;
                       cli)
-                        memory_request=25Mi
-                        memory_limit=125Mi
+                        memory_request=250Mi
+                        memory_limit=1Gi
                         ;;
                       *)
                         memory_request=150Mi

--- a/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
+++ b/infrastructure/environments/dplplat01/configuration/patch-pr-env-resource-requests/chart/templates/patch-cms-bnf-deployments.yaml
@@ -4,7 +4,7 @@ metadata:
   name: patch-resource-requests
   namespace: default
 spec:
-  schedule: "0 */6 * * *" # Every 6 hours
+  schedule: "0 */2 * * *" # Every 2 hours
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
…jobs without being OOM'ed

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
It should fix CLI being OOM'ed on the DPL CMS and BNF projects. It will also run more often now. It should take up a lot more resource from doing so 

#### Should this be tested by the reviewer and how?
Just read it

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-324