### PR TITLE
only select those that have failed, so we don't redeploy queued or ca…

### DIFF
--- a/infrastructure/images/lagoon-redeploy-controller/redeploy-controller.mjs
+++ b/infrastructure/images/lagoon-redeploy-controller/redeploy-controller.mjs
@@ -37,7 +37,7 @@ function getFailedDeployments(environmentType) {
         }
       }
     }
-  }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status != "complete") | ($name)'`.valueOf().split("\n");
+  }" | jq -r '.allProjects[] | .name as $name | .environments[].deployments[] | select(.status == "failed") | ($name)'`.valueOf().split("\n");
 }
 
 const redeployedDeployments = {};


### PR DESCRIPTION
…ncelled deployments

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
The first version of the redeploy controller redeployed queued deployments, and we do not want that. This PR changes it to only redeploy those that have failed.

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?
Just read it 

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-264