### PR TITLE
Handle sites not having prop has go

### DIFF
--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -100,6 +100,10 @@ function getSiteSecondaryDomains {
 function projectHasGo {
     local hasGo
     hasGo=$(yq eval ".sites.${1}.hasGo" "${2}")
+     if [[ "${hasGo}" == "null" ]]; then
+        echo "false"
+        return
+    fi
     if [[ -z "${hasGo}" ]]; then
         echo "Error: hasGo should have a boolean value"
         exit 1

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -116,7 +116,7 @@ function projectHasGo {
         echo "false"
         return
     fi
-    echo "Error: has should a boolean value"
+    echo "Error: hasGo should a boolean value"
     exit 1
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Found out we didn't handle sites in `sites.yaml` not having `hasGo` prop. This resulted in the primary go-subdomain being set. 
This PR fixes this

#### Should this be tested by the reviewer and how?
This can be tested on canary by running `SITE=canary task site:sync` and then going to https://github.com/danishpubliclibraries/env-canary/blob/main/.lagoon.yml#L60
If it works, there should be no domains routing to any services if there's no `hasGo` prop on canary. 

#### Any specific requests for how the PR should be reviewed?
Please read it and test it

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-323