### PR TITLE
Moduletest missed stuff

### DIFF
--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -1,5 +1,5 @@
 # This manifest will fire up a customer Kubernetes Job in moduletest namepaces.
-# It will synchronize all files from the corresponding main environment to the moduletest environment
+# It will synchronize all files as well as the database from the corresponding main environment to the moduletest environment
 
 {{ range .Values.projects }}
 

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -38,6 +38,7 @@ spec:
                   values:
                    - prod
 
+---
 {{ end }}
 
 ---

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-          image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-0.0.25-rc
         - name: moduletest-reset-container
+          image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-1.0.1
           command:
             - /bin/bash
             - -c

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -6,9 +6,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: file-reset-{{ . }}
+  name: moduletest-reset-{{ . }}
   labels:
-    app: moduletest-file-reset-job
+    app: moduletest-reset-job
 spec:
   ttlSecondsAfterFinished: 36000 # 10 hours leaving time to investigate failed jobs
   backoffLimit: 3
@@ -16,8 +16,8 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: file-reset-container
           image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-0.0.25-rc
+        - name: moduletest-reset-container
           command:
             - /bin/bash
             - -c

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -7,8 +7,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: moduletest-reset-{{ . }}
-  labels:
-    app: moduletest-reset-job
 spec:
   ttlSecondsAfterFinished: 36000 # 10 hours leaving time to investigate failed jobs
   backoffLimit: 3

--- a/infrastructure/images/moduletest-reset-job/values.yaml
+++ b/infrastructure/images/moduletest-reset-job/values.yaml
@@ -1,2 +1,16 @@
 projects:
   - canary
+  - customizable-canary
+  - kobenhavn
+  - faxe
+  - albertslund
+  - aalborg
+  - aarhus
+  - ballerup
+  - herning
+  - odense
+  - roskilde
+  - silkeborg
+  - sonderborg
+  - sydslesvig
+  - taarnby


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR add's some stuff which I missed in the previous related PR, namely some renaming.
This PR also adds, very crucially, a version bump to the first real release as well as a complete list of webmaster projects that need moduletest sites reset to their main sites every release.

#### Should this be tested by the reviewer and how?
Just read it. Especially the list of projects to be run on, should be reviewed thoroughly.

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFDRIFT-264