### PR TITLE
set min and maxAllowed for other containers that run in the CLI pod

### DIFF
--- a/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
+++ b/infrastructure/dpladm/vpa-templates/cli-vpa.template.yaml
@@ -18,4 +18,25 @@ spec:
         memory: 2Mi
       maxAllowed:
         cpu: 150m
-        memory: 250Mi
+        memory: 400Mi
+    - containerName: cronjob-cli-drush-err-purge
+      minAllowed:
+        cpu: 4m
+        memory: 10Mi
+      maxAllowed:
+        cpu: 250m
+        memory: 210Mi
+    - containerName: cronjob-cli-import-danish-config-translations
+      minAllowed:
+        cpu: 70m
+        memory: 90Mi
+      maxAllowed:
+        cpu: 250m
+        memory: 220Mi
+    - containerName: cronjob-cli-import-translations
+      minAllowed:
+        cpu: 70m
+        memory: 50Mi
+      maxAllowed:
+        cpu: 350m
+        memory: 200Mi


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
I noticed that the CLI pod accross namespaces, were allowed a lot of resouces, somtimes reaching an allowance of over a terrabyte of memory, but in most cases just being allowed to use up to 33Gb of memory. This PR seeks to have the CLI pod's VPA recommend some more sane defaults.

#### Should this be tested by the reviewer and how?
Just read it

#### Any specific requests for how the PR should be reviewed?
Just read it 

#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-264