### PR TITLE
Upgrade bnf site to use the webmaster plan

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -68,6 +68,14 @@ sites:
   bnf:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
+    plan: webmaster
+    moduletest-dpl-cms-release: "2025.15.1"
+    # Use the webmaster plan to add a module-test site which acts as a server
+    # for the staging environment.
+    # The module-test site should use the next version while the production
+    # environment should use the latest version.
+    # Our YAML handling chokes on duplicates so we follow the default release
+    # plan and update the module test site manually.
     <<: *default-release-image-source
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICTmMC/cUI3U3QloX6aAdN7g0EU42J0fwA9aO7UJOzx9
     primary-domain: delingstjenesten.dk


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Upgrade bnf site to use the webmaster plan

We need a site to act as a server when testing the the content sharing system on staging which in this context acts as a client. To test recent changes it is usually required that the client and server both use the newest version.

To provide this we update the bnf site to use the webmaster plan. We can use the module-test site to act as a server and our current workflows ensures that it is kept up to date with recent content.

The staging site currently acts as a client.

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
