### PR TITLE
Revert "Sites version variables"

### DIFF
--- a/docs/runbooks/how-release-a-new-version-for-approval-testing.md
+++ b/docs/runbooks/how-release-a-new-version-for-approval-testing.md
@@ -20,8 +20,10 @@ production library sites.
 1. In your local environment ensure that your checkout of the `main` branch for
    `dpl-platform` is up to date.
 2. Create a new branch from `main`.
-3. Open `infrastructure/environments/dplplat01/sites.yaml` and bump
-   `x-next-version` anchor to the new version.
+3. Open `infrastructure/environments/dplplat01/sites.yaml`
+   1. Set the value of `dpl-cms-release` and `moduletest-dpl-cms-release` for
+      `staging` to the new version
+   2. Set the value of `moduletest-dpl-cms-release` for `bnf` to the new version
 4. Commit the change and push your branch to GitHub and create a pull request.
 5. Request a review for the change and wait for approval.
 6. Start `dplsh` from the `/infrastructure` directory of your local

--- a/docs/runbooks/weekly-release-to-editors-and-moduletests.md
+++ b/docs/runbooks/weekly-release-to-editors-and-moduletests.md
@@ -19,8 +19,11 @@ the production environments of webmasters.
 1. In your local environment ensure that your checkout of the `main`
    branch for `dpl-platform` is up to date.
 2. Create a new branch from `main`.
-3. Now update `infrastructure/environments/dplplat01/sites.yaml`. Bump
-   `x-latest-version` anchor to the new version.
+3. Now update `infrastructure/environments/dplplat01/sites.yaml`. The
+    `x-defaults` anchors' `dpl-cms-release` tag should be bumped to
+    the new version. Then update the `moduletest-dpl-cms-release` of
+    `x-webmaster` to the same version. Update the same property for
+    the `x-webmaster-with-defaults` anchor.
 4. Commit the change and push your branch to GitHub and create a pull
    request.
 5. Request a review for the change and wait for approval.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -1,12 +1,8 @@
-# Configure the usual versions we are working with for release cycles and sites.
-x-latest-release: &latest-release "2025.15.1"
-x-next-release: &next-release "2025.15.1"
-x-previous-release: &previous-release "2025.14.3"
 # Configure the source we default to when looking for release images.
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: *latest-release
+  dpl-cms-release: "2025.15.1"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
@@ -18,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: *previous-release
-  moduletest-dpl-cms-release: *latest-release
+  dpl-cms-release: "2025.14.3"
+  moduletest-dpl-cms-release: "2025.15.1"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -29,9 +25,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: *latest-release
+    dpl-cms-release: "2025.15.1"
     plan: webmaster
-    moduletest-dpl-cms-release: *latest-release
+    moduletest-dpl-cms-release: "2025.15.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -39,24 +35,24 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: *latest-release
-    moduletest-dpl-cms-release: *latest-release
+    dpl-cms-release: "2025.15.1"
+    moduletest-dpl-cms-release: "2025.15.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: *next-release
+    dpl-cms-release: "2025.15.1"
     plan: webmaster
-    moduletest-dpl-cms-release: *next-release
+    moduletest-dpl-cms-release: "2025.15.1"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
-    moduletest-dpl-cms-release: *latest-release
+    moduletest-dpl-cms-release: "2025.15.1"
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we
     # follow the default release plan and update the module test site manually.
@@ -73,7 +69,7 @@ sites:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
     plan: webmaster
-    moduletest-dpl-cms-release: *next-release
+    moduletest-dpl-cms-release: "2025.15.1"
     # Use the webmaster plan to add a module-test site which acts as a server
     # for the staging environment.
     # The module-test site should use the next version while the production


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-platform#661

It does not work in the current version. It outputs the literal name of the anchors instead of the value. It seems to be a problem with yq. I wonder how this ever worked.