### PR TITLE
2025.17.1 on staging

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,6 +43,8 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
+    # Remember to update bnf.moduletest-dpl-cms-release to the same release
+    # to make client and server use the same version.
     dpl-cms-release: "2025.17.1"
     plan: webmaster
     moduletest-dpl-cms-release: "2025.17.1"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,9 +43,9 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.17.0"
+    dpl-cms-release: "2025.17.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.17.0"
+    moduletest-dpl-cms-release: "2025.17.1"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"
@@ -69,7 +69,7 @@ sites:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.15.1"
+    moduletest-dpl-cms-release: "2025.17.1"
     # Use the webmaster plan to add a module-test site which acts as a server
     # for the staging environment.
     # The module-test site should use the next version while the production


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2025.17.1 on staging.

This has already been applied.