### PR TITLE
Release week 18.1

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -25,9 +25,9 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.17.0"
+    dpl-cms-release: "2025.17.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.17.0"
+    moduletest-dpl-cms-release: "2025.17.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -35,8 +35,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.17.0"
-    moduletest-dpl-cms-release: "2025.17.0"
+    dpl-cms-release: "2025.17.1"
+    moduletest-dpl-cms-release: "2025.17.1"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,6 +43,8 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
+    # Remember to update bnf.moduletest-dpl-cms-release to the same release
+    # to make client and server use the same version.
     dpl-cms-release: "2025.17.1"
     plan: webmaster
     moduletest-dpl-cms-release: "2025.17.1"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -54,7 +54,7 @@ sites:
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.17.0"
+    moduletest-dpl-cms-release: "2025.17.1"
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we
     # follow the default release plan and update the module test site manually.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -43,9 +43,9 @@ sites:
     description: "A site to test new releases on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.17.0"
+    dpl-cms-release: "2025.17.1"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.17.0"
+    moduletest-dpl-cms-release: "2025.17.1"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"
@@ -69,7 +69,7 @@ sites:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
     plan: webmaster
-    moduletest-dpl-cms-release: "2025.15.1"
+    moduletest-dpl-cms-release: "2025.17.1"
     # Use the webmaster plan to add a module-test site which acts as a server
     # for the staging environment.
     # The module-test site should use the next version while the production

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.17.0"
+  dpl-cms-release: "2025.17.1"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.15.1"
-  moduletest-dpl-cms-release: "2025.17.0"
+  dpl-cms-release: "2025.15.2"
+  moduletest-dpl-cms-release: "2025.17.1"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This follows the release plan for the first releases this week with patches:

- Most production sites: 2025.17.1
- Webmaster sites get
  - Production: 2025.15.2
  - Module test: 2025.17.1 


#### Any specific requests for how the PR should be reviewed?

Just read it.
