### PR TITLE
Adjustments to mariadb server values

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -48,6 +48,7 @@ spec:
     innodb_autoinc_lock_mode=2
     binlog_format=row
     max_connections=125
+    wait_timeout=180
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -80,7 +80,7 @@ spec:
         - bash
         - -c
         - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
-    initialDelaySeconds: 20
+    initialDelaySeconds: 300
     periodSeconds: 5
     timeoutSeconds: 5
 
@@ -90,12 +90,12 @@ spec:
         - bash
         - -c
         - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
-    initialDelaySeconds: 20
+    initialDelaySeconds: 300
     periodSeconds: 5
     timeoutSeconds: 5
 
   podDisruptionBudget:
-    maxUnavailable: 50%
+    maxUnavailable: 40%
 
   updatestrategy:
     type: ReplicasFirstPrimaryLast

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -49,6 +49,7 @@ spec:
     binlog_format=row
     max_connections=125
     wait_timeout=180
+    transaction_isolation="READ-COMMITTED"
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -45,6 +45,7 @@ spec:
     bind-address=*
     default_storage_engine=InnoDB
     binlog_format=row
+    innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
     max_allowed_packet=256M
 

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -48,6 +48,7 @@ spec:
     innodb_autoinc_lock_mode=2
     binlog_format=row
     max_allowed_packet=1GB
+    max_connections=300
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -47,7 +47,7 @@ spec:
     innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
     binlog_format=row
-    max_connections=300
+    max_connections=100
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -113,3 +113,21 @@ spec:
 
   secondaryService:
     type: ClusterIP
+
+  priorityClassName: system-node-critical
+
+  tolerations:
+    - effect: NoSchedule
+      key: noderole.dplplatform
+      operator: Equal
+      value: prod
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: noderole.dplplatform
+            operator: In
+            values:
+            - prod

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -44,10 +44,10 @@ spec:
     [mariadb]
     bind-address=*
     default_storage_engine=InnoDB
-    binlog_format=row
     innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
     max_allowed_packet=256M
+    binlog_format=row
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -47,7 +47,7 @@ spec:
     innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
     binlog_format=row
-    max_connections=100
+    max_connections=125
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -80,7 +80,7 @@ spec:
         - bash
         - -c
         - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
-    initialDelaySeconds: 300
+    initialDelaySeconds: 30
     periodSeconds: 5
     timeoutSeconds: 5
 
@@ -90,7 +90,7 @@ spec:
         - bash
         - -c
         - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
-    initialDelaySeconds: 300
+    initialDelaySeconds: 30
     periodSeconds: 5
     timeoutSeconds: 5
 
@@ -113,8 +113,6 @@ spec:
 
   secondaryService:
     type: ClusterIP
-
-  priorityClassName: system-node-critical
 
   tolerations:
     - effect: NoSchedule

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -46,8 +46,8 @@ spec:
     default_storage_engine=InnoDB
     innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
-    max_allowed_packet=256M
     binlog_format=row
+    max_allowed_packet=1GB
 
   myCnfConfigMapKeyRef:
     name: mariadb

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/templates/mariadb-server.template.yaml
@@ -47,7 +47,6 @@ spec:
     innodb_buffer_pool_size=3200MB
     innodb_autoinc_lock_mode=2
     binlog_format=row
-    max_allowed_packet=1GB
     max_connections=300
 
   myCnfConfigMapKeyRef:

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/upgrade.sh
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/upgrade.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+helm upgrade mariadb-servers . \
+  --namespace mariadb-servers \
+  --create-namespace \
+  --install \
+  -f values.yaml

--- a/infrastructure/environments/dplplat01/configuration/mariadb-servers/values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/mariadb-servers/values.yaml
@@ -3,5 +3,5 @@ name: mariadb-10-6-01
 mariadbVersion: 10.6
 replicas: 5
 storageSize: 60Gi
-resReqMemory: 1Gi
-resReqCpu: 200m
+resReqMemory: 4Gi
+resReqCpu: 1


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Overall this PR ensures operational reliability by: 
- Increasing InnoDB's memory allowance
- assigning DB workloads to autoscaled nodes 
- Requesting more CPU and memory per DB
- setting allows connections to 300 (might increase later)
- telling livenessProbe and readinessProbe wait longer
- labelling the DB workloads as critical, thus disallowing Kubernetes killing them to allocate workloads

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?label=MariaDB&selectedIssue=DDFDRIFT-347