### PR TITLE
Revert "we need to set primary domains for these sites inorder for adgangstje…"

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -27,7 +27,6 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: "2025.20.0"
     plan: webmaster
-    primary-domain: canary.dplplat01.dpl.reload.dk
     moduletest-dpl-cms-release: "2025.20.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
@@ -47,16 +46,14 @@ sites:
     # Remember to update bnf.moduletest-dpl-cms-release to the same release
     # to make client and server use the same version.
     dpl-cms-release: "2025.21.1"
-    moduletest-dpl-cms-release: "2025.21.1"
     plan: webmaster
-    primary-domain: staging.dplplat01.dpl.reload.dk
+    moduletest-dpl-cms-release: "2025.21.1"
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"
     description: "Et site til undervisning i CMSet"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
-    primary-domain: cms-school.dplplat01.dpl.reload.dk
     moduletest-dpl-cms-release: "2025.20.0"
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-platform#690

These changes update which urls the sites are accessible at. They have not been whitelisted at Adgangsplatformen yet and this makes it impossible to login as a patron until this has happended. This in turn prevents testing.