### PR TITLE
Release week 21

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -16,6 +16,14 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.20.0"
   moduletest-dpl-cms-release: "2025.21.2"
+x-webmasters-on-latest-release: &x-webmasters-on-latest-release
+  #This release cycle releases the newest release on both production and moduletest sites.
+  #This is relevant for webmaster sites acting as pilots for new features.
+  #Currently: Go
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
+  dpl-cms-release: "2025.21.2"
+  moduletest-dpl-cms-release: "2025.21.2"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -149,7 +157,7 @@ sites:
       - www.albertslundbibliotek.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-on-weekly-release-cycle
+    <<: *x-webmasters-on-latest-release
   allerod:
     name: "Allerød Biblioteker"
     description: "The library site for Allerød"
@@ -435,7 +443,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-on-weekly-release-cycle
+    <<: *x-webmasters-on-latest-release
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"
@@ -804,7 +812,7 @@ sites:
       - www.silkeborgbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-on-weekly-release-cycle
+    <<: *x-webmasters-on-latest-release
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -443,7 +443,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *x-webmasters-on-latest-release
+    <<: *webmasters-on-weekly-release-cycle
   hillerod:
     name: "Hillerød Bibliotekerne"
     description: "The library site for Hillerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,7 +2,7 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.20.0"
+  dpl-cms-release: "2025.21.2"
 x-webmaster: &webmaster-release-image-source
   # This is the default release plan for webmasters. There's currently no webmasters on it.
   # This is should be updated according with https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/monthly-release-to-editors-and-webmasters/
@@ -25,13 +25,13 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: "2025.20.0"
+    dpl-cms-release: "2025.21.2"
     plan: webmaster
     primary-domain: canary.dplplat01.dpl.reload.dk
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
     # has been updated to use the primary domain.
     autogenerateRoutes: true
-    moduletest-dpl-cms-release: "2025.20.0"
+    moduletest-dpl-cms-release: "2025.21.2"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
     name: "Customizable bibliotek - eksempel"
@@ -39,8 +39,8 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: "2025.20.0"
-    moduletest-dpl-cms-release: "2025.20.0"
+    dpl-cms-release: "2025.21.2"
+    moduletest-dpl-cms-release: "2025.21.2"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
     name: "Staging"
@@ -66,7 +66,7 @@ sites:
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
     # has been updated to use the primary domain.
     autogenerateRoutes: true
-    moduletest-dpl-cms-release: "2025.20.0"
+    moduletest-dpl-cms-release: "2025.21.2"
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we
     # follow the default release plan and update the module test site manually.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -14,8 +14,8 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.19.0"
-  moduletest-dpl-cms-release: "2025.20.0"
+  dpl-cms-release: "2025.20.0"
+  moduletest-dpl-cms-release: "2025.21.2"
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -157,7 +157,7 @@ sites:
       - www.albertslundbibliotek.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *x-webmasters-on-latest-release
+    <<: *webmasters-on-weekly-release-cycle
   allerod:
     name: "Allerød Biblioteker"
     description: "The library site for Allerød"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -28,6 +28,9 @@ sites:
     dpl-cms-release: "2025.20.0"
     plan: webmaster
     primary-domain: canary.dplplat01.dpl.reload.dk
+    # TODO: Remove this once the the Adgangsplatformen OpenID client used here
+    # has been updated to use the primary domain.
+    autogenerateRoutes: true
     moduletest-dpl-cms-release: "2025.20.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
   customizable-canary:
@@ -50,6 +53,9 @@ sites:
     moduletest-dpl-cms-release: "2025.21.2"
     plan: webmaster
     primary-domain: staging.dplplat01.dpl.reload.dk
+    # TODO: Remove this once the the Adgangsplatformen OpenID client used here
+    # has been updated to use the primary domain.
+    autogenerateRoutes: true
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLUrrxfwsfwz4nkn/WCbMUbLHkTFvyYB2uusHLA7NlH
   cms-school:
     name: "CMS-skole"
@@ -57,6 +63,9 @@ sites:
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ6SzfPFf/XeLeqI342kxuJAlATpDMtgAfqlrLTTbW2m"
     plan: webmaster
     primary-domain: cms-school.dplplat01.dpl.reload.dk
+    # TODO: Remove this once the the Adgangsplatformen OpenID client used here
+    # has been updated to use the primary domain.
+    autogenerateRoutes: true
     moduletest-dpl-cms-release: "2025.20.0"
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy versions 2025.21.2 and 2025.20 to sites.

This PR includes a change related to #690 as we need to keep the autogenerated routes available on some sites.

#### Any specific requests for how the PR should be reviewed?

Just read it.
