### PR TITLE
Improve moduletest reset job

### DIFF
--- a/infrastructure/images/moduletest-reset-job/Dockerfile
+++ b/infrastructure/images/moduletest-reset-job/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine
 
 # Install apk dependencies
-RUN apk add --no-cache bash kubectl && npm install -g zx
+RUN apk add --no-cache bash kubectl && npm install -g zx && apk add jq
 
 WORKDIR /usr/src/app
 

--- a/infrastructure/images/moduletest-reset-job/Dockerfile
+++ b/infrastructure/images/moduletest-reset-job/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine
 
 # Install apk dependencies
-RUN apk add --no-cache bash kubectl && npm install -g zx && apk add jq
+RUN apk add --no-cache bash kubectl && npm install -g zx
 
 WORKDIR /usr/src/app
 

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -18,6 +18,8 @@ await syncFileFromSourceToTarget(projectName);
 
 await runDrushDeployForStateTransferToTakeEffect();
 
+echo(`File reset for ${projectName} complete`);
+
 
 async function runDrushDeployForStateTransferToTakeEffect() {
   echo(`Starting 'drush deploy' in ${projectName}-moduletest`);

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -5,7 +5,6 @@ if (!projectName) {
   throw Error("No 'projectName' provided");
 }
 
-echo(`Will now sync databases from ${projectName}-main to ${projectName}-moduletest`);
 const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
 
 try {

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -38,7 +38,7 @@ try {
 
 echo(`Now moving files from ${projectName}-main to ${projectName}-moduletest`);
 try {
-  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush -y rsync @lagoon.${projectName}-main:%files @self:%files -- --omit-dir-times --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded"`
+  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rsync --omit-dir-times --recursive --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded ${projectName}-main@20.238.147.183:/app/web/sites/default/files/ /app/web/sites/default/files/"`
 } catch(error) {
   echo("The file move failed for ${projectName} moduletest", error.stderr);
   throw Error("The file move failed for ${projectName} moduletest", { cause: error });

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -6,6 +6,7 @@ if (!projectName) {
 }
 
 echo(`Will now sync databases from ${projectName}-main to ${projectName}-moduletest`);
+const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
 
 try {
   await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush sql-drop -y; drush -y sql-sync @lagoon.${projectName}-main @self --create-db"`

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -33,8 +33,10 @@ async function runDrushDeployForStateTransferToTakeEffect() {
 
 async function syncFileFromSourceToTarget(projectName) {
   echo(`Now moving files from ${projectName}-main to ${projectName}-moduletest`);
+  // The IP here is the lagoon SSH host and it is documented here: https://github.com/danskernesdigitalebibliotek/dpl-platform/blob/main/docs/runbooks/connecting-the-lagoon-cli.md#configure-your-local-lagoon-cli
+  const sshHost = "20.238.147.183";
   try {
-      await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rsync --omit-dir-times --recursive --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded ${projectName}-main@20.238.147.183:/app/web/sites/default/files/ /app/web/sites/default/files/"`;
+      await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rsync --omit-dir-times --recursive --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded ${projectName}-main@${sshHost}:/app/web/sites/default/files/ /app/web/sites/default/files/"`;
   } catch (error) {
       echo(`The file move failed for ${projectName} moduletest`, error.stderr);
       throw Error(`The file move failed for ${projectName} moduletest`, { cause: error });

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -78,7 +78,6 @@ async function getDatabaseConnectionInfo(namespace) {
   return databaseConnectionInfo;
 }
 
-echo(`File reset for ${projectName} complete`);
 async function makeDatabaseDump(databaseConnectionInfo, projectName) {
   echo(`Dumping ${projectName}-main's database to file`);
 

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -54,25 +54,20 @@ async function getDatabaseConnectionInfo(namespace) {
   const configmap = JSON.parse(configMapJson);
   const { data } = configmap;
 
-  let databaseConnectionInfo = {
-    databaseName: "",
-    databaseHost: "",
-    databaseUser: "",
-    databasePassword : "",
+  const databaseConnectionInfo = {
+    databaseName: data.MARIADB_DATABASE,
+    databaseHost: data.MARIADB_HOST,
+    databaseUser:  data.MARIADB_USERNAME,
+    databasePassword: data.MARIADB_PASSWORD,
+    override: false,
   };
 
-  if(data.OVERRIDE_MARIADB_DATABASE != undefined) {
+  if(data.OVERRIDE_MARIADB_DATABASE) {
     databaseConnectionInfo.databaseName = data.OVERRIDE_MARIADB_DATABASE;
     databaseConnectionInfo.databaseHost = data.OVERRIDE_MARIADB_HOST;
     databaseConnectionInfo.databasePassword = data.OVERRIDE_MARIADB_PASSWORD;
     databaseConnectionInfo.databaseUser = data.OVERRIDE_MARIADB_USERNAME;
     databaseConnectionInfo.override = true;
-  } else {
-    databaseConnectionInfo.databaseName = data.MARIADB_DATABASE;
-    databaseConnectionInfo.databaseHost = data.MARIADB_HOST;
-    databaseConnectionInfo.databasePassword = data.MARIADB_PASSWORD;
-    databaseConnectionInfo.databaseUser = data.MARIADB_USERNAME;
-    databaseConnectionInfo.override = false;
   }
 
   return databaseConnectionInfo;

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -7,41 +7,11 @@ if (!projectName) {
 
 const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
 
-try {
-  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush sql-drop -y; drush -y sql-sync @lagoon.${projectName}-main @self --create-db"`
-} catch(error) {
-  echo("Database sync for ${projectName} moduletest failed", error.stderr);
-  throw Error("Database sync for ${projectName} moduletest failed", { cause: error });
-}
 
-echo(`Database reset for ${projectName} complete`);
 
-echo(`Reseting files from ${projectName}-main to ${projectName}-moduletest
-  \n
-  Will now delete all files and folder in '/app/web/sites/default/files'
-  \n
-  on ${projectName}-moduletest
-`);
-
-try {
-  // This will throw as there's a long running PHP process that keeps using
-  // a file in a /php folder inside the CLI container
-  // Emptying the folder is however successfull and we should ensure the
-  // program doesn't exit;
-  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rm -fr /app/web/sites/default/files"`
-} catch(error) {
-  if(error.exitCode != 1) {
-    throw Error("unexpected error", { cause: error });
   }
-  echo("As expected, the deletion of all files and folders in '/app/web/default/files' threw an 'exit 1'", error);
 }
 
-echo(`Now moving files from ${projectName}-main to ${projectName}-moduletest`);
-try {
-  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rsync --omit-dir-times --recursive --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded ${projectName}-main@20.238.147.183:/app/web/sites/default/files/ /app/web/sites/default/files/"`
-} catch(error) {
-  echo("The file move failed for ${projectName} moduletest", error.stderr);
-  throw Error("The file move failed for ${projectName} moduletest", { cause: error });
 }
 
 

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -14,10 +14,19 @@ const targetNamespace = projectName + "-moduletest";
 const targetDatabaseConnectionInfo = await getDatabaseConnectionInfo(targetNamespace);
 await importMainDumpIntoModuletestDatabase(targetDatabaseConnectionInfo, projectName);
 
+await syncFileFromSourceToTarget(projectName);
 
   }
 }
 
+async function syncFileFromSourceToTarget(projectName) {
+  echo(`Now moving files from ${projectName}-main to ${projectName}-moduletest`);
+  try {
+      await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "rsync --omit-dir-times --recursive --no-perms --no-group --no-owner --no-times --chmod=ugo=rwX --delete --exclude=css/* --exclude=js/* --exclude=styles/* --delete-excluded ${projectName}-main@20.238.147.183:/app/web/sites/default/files/ /app/web/sites/default/files/"`;
+  } catch (error) {
+      echo(`The file move failed for ${projectName} moduletest`, error.stderr);
+      throw Error(`The file move failed for ${projectName} moduletest`, { cause: error });
+  }
 }
 
 async function getDatabaseConnectionInfo(namespace) {

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -86,6 +86,15 @@ async function makeDatabaseDump(databaseConnectionInfo, projectName) {
 
   echo(`Database dump for ${projectName} complete`);
 }
+
+function getDatabaseHost(databaseHost, projectName, override = false) {
+  // We are in the middle of switching to an incluster database. We therefore need to use the database the site is using to make a database transfer
+  if(override === true) {
+    return databaseHost;
+  }
+  return azureDatabaseHost;
+}
+
 async function importMainDumpIntoModuletestDatabase(databaseConnectionInfo, projectName) {
   echo(`Importing ${projectName}-main's database dump in to ${projectName}-moduletest's database`);
 

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -7,6 +7,10 @@ if (!projectName) {
 
 const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
 
+const sourceNamespace = projectName + "-main";
+const sourceDatabaseConnectionInfo = await getDatabaseConnectionInfo(sourceNamespace);
+const targetNamespace = projectName + "-moduletest";
+const targetDatabaseConnectionInfo = await getDatabaseConnectionInfo(targetNamespace);
 
 
   }
@@ -14,6 +18,18 @@ const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
 
 }
 
+async function getDatabaseConnectionInfo(namespace) {
+  echo(`Getting ${namespace}'s database connection details`);
+  let configMapJson;
+  try {
+    configMapJson = await $`kubectl get -n ${namespace} configmap lagoon-env -o json`
+  } catch(error) {
+    echo(`Failed to get configmap "lagoon-env" in namespace ${namespace}`, error.stderr);
+    throw Error(`Failed to get configmap "lagoon-env" in namespace ${namespace}`, { cause: error });
+  }
+
+  const configmap = JSON.parse(configMapJson);
+  const { data } = configmap;
 
 echo(`Starting 'drush deploy' in ${projectName}-moduletest`);
 try {
@@ -21,6 +37,28 @@ try {
 } catch(error) {
   echo("The file move failed for ${projectName} moduletest", error.stderr);
   throw Error("The file move failed for ${projectName} moduletest", { cause: error });
+  let databaseConnectionInfo = {
+    databaseName: "",
+    databaseHost: "",
+    databaseUser: "",
+    databasePassword : "",
+  };
+
+  if(data.OVERRIDE_MARIADB_DATABASE != undefined) {
+    databaseConnectionInfo.databaseName = data.OVERRIDE_MARIADB_DATABASE;
+    databaseConnectionInfo.databaseHost = data.OVERRIDE_MARIADB_HOST;
+    databaseConnectionInfo.databasePassword = data.OVERRIDE_MARIADB_PASSWORD;
+    databaseConnectionInfo.databaseUser = data.OVERRIDE_MARIADB_USERNAME;
+    databaseConnectionInfo.override = true;
+  } else {
+    databaseConnectionInfo.databaseName = data.MARIADB_DATABASE;
+    databaseConnectionInfo.databaseHost = data.MARIADB_HOST;
+    databaseConnectionInfo.databasePassword = data.MARIADB_PASSWORD;
+    databaseConnectionInfo.databaseUser = data.MARIADB_USERNAME;
+    databaseConnectionInfo.override = false;
+  }
+
+  return databaseConnectionInfo;
 }
 
 echo(`File reset for ${projectName} complete`);

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -16,6 +16,16 @@ await importMainDumpIntoModuletestDatabase(targetDatabaseConnectionInfo, project
 
 await syncFileFromSourceToTarget(projectName);
 
+await runDrushDeployForStateTransferToTakeEffect();
+
+
+async function runDrushDeployForStateTransferToTakeEffect() {
+  echo(`Starting 'drush deploy' in ${projectName}-moduletest`);
+  try {
+      await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush deploy"`;
+  } catch (error) {
+      echo(`Failed to run drush deploy from CLI pod in namespace ${projectName}-moduletest`, error.stderr);
+      throw Error(`Failed to run drush deploy from CLI pod in namespace ${projectName}-moduletest`, { cause: error });
   }
 }
 
@@ -42,12 +52,6 @@ async function getDatabaseConnectionInfo(namespace) {
   const configmap = JSON.parse(configMapJson);
   const { data } = configmap;
 
-echo(`Starting 'drush deploy' in ${projectName}-moduletest`);
-try {
-  await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush deploy"`
-} catch(error) {
-  echo("The file move failed for ${projectName} moduletest", error.stderr);
-  throw Error("The file move failed for ${projectName} moduletest", { cause: error });
   let databaseConnectionInfo = {
     databaseName: "",
     databaseHost: "",

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: moduletest-reset-container
-          image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-1.0.1
+          image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-1.0.38-rc
           command:
             - /bin/bash
             - -c

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -20,6 +20,12 @@ spec:
             - /bin/bash
             - -c
             - ./moduletest-reset-job.mjs {{ . }}
+          env:
+            - name: AZURE_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: azure-database-host
+                  key: host
       serviceAccountName: moduletest-reset-serviceaccount
       tolerations:
         - key: noderole.dplplatform

--- a/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
+++ b/infrastructure/images/moduletest-reset-job/templates/moduletest-reset-job.template.yaml
@@ -62,9 +62,9 @@ metadata:
   namespace: moduletest-reset
 rules:
 - apiGroups: [""]
-  resources: [ "namespaces", "pods", "pods/exec" ]
+  resources: [ "namespaces", "pods", "pods/exec", "configmaps" ]
   verbs: [ "get", "list", "create" ]
-- apiGroups: [ "apps" ]
+- apiGroups: [ "apps", "configmaps" ]
   resources: [ "deployments", "pods" ]
   verbs: [ "get", "list" ]
 

--- a/infrastructure/images/moduletest-reset-job/upgrade.sh
+++ b/infrastructure/images/moduletest-reset-job/upgrade.sh
@@ -1,0 +1,7 @@
+#!/bin/env bash
+
+helm upgrade moduletest-reset . \
+  --namespace moduletest-reset \
+  --create-namespace \
+  --install \
+  -f values.yaml


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR is an improvement upon the last iteration. The main improvement here is the use of underlying tools, which Lagoon also uses, but which for some reason keeps breaking or stop working for us. 

#### Should this be tested by the reviewer and how?
This can be tested by firstly, removing all sites from `value.yaml` but canary or customizable. Then add an image to the main site. Run the `Job` and check moduletest for the image. It hsould be there. 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-264