### PR TITLE
Herning is no longer a GO pilot, so remove them

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -450,7 +450,6 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    go-release: 0.25.11
     <<: *webmasters-on-weekly-release-cycle
   hillerod:
     name: "Hillerød Bibliotekerne"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
Herning is not a GO pilot, so to keep everything in order, let's remove that prop from them in `sites.yaml`

#### Should this be tested by the reviewer and how?
just read it

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
