### PR TITLE
add sites and workloads which should run on prod nodes

### DIFF
--- a/infrastructure/task/scripts/promote-workloads-to-prod-nodes.sh
+++ b/infrastructure/task/scripts/promote-workloads-to-prod-nodes.sh
@@ -21,6 +21,8 @@ PROMOTED_NAMESPACES=(
   "bibliotek-test-main"
   "bibliotek-test-moduletest"
   "billund-main"
+  "bnf-main"
+  "bnf-moduletest"
   "bornholm-main"
   "brondby-main"
   "bronderslev-main"
@@ -117,6 +119,7 @@ PROMOTED_NAMESPACES=(
   "taarnby-main"
   "taarnby-moduletest"
   "thisted-main"
+  "torshavn-main"
   "vallensbaek-main"
   "varde-main"
   "vejen-main"
@@ -126,7 +129,7 @@ PROMOTED_NAMESPACES=(
   "vordingborg-main"
 )
 
-DEPLOYMENTS=("cli" "nginx" "varnish" "redis")
+DEPLOYMENTS=("cli" "nginx" "varnish" "redis" "node")
 
 NAMESPACES_RAW=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}')
 # shellcheck disable=SC2206


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
We've added some sites which we haven't added the list of workloads which are promoted to run on production nodes. 
With GO we're also adding a node workload which should also be scheduled to run on production nodes

#### Should this be tested by the reviewer and how?
Just read it 

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
