### PR TITLE
this the anchor to be used for webmasters that have go, from week 26 …

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -30,6 +30,13 @@ x-go-release-pilot-sites: &go-release-pilot-sites
   dpl-cms-release: "2025.25.0"
   moduletest-dpl-cms-release: "2025.25.0"
   go-release: 0.25.44
+x-webmaster-weekly-release-cycle-with-go: &x-webmaster-weekly-release-cycle-with-go
+  #To be used from week 26 and onwards
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
+  dpl-cms-release: "2025.25.0"
+  moduletest-dpl-cms-release: "2025.26.0"
+  go-release: 0.25.44
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.


### PR DESCRIPTION
…and onwards

<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR will allow us to move the webmasters having GO, back on their regular release cycle

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-380