### PR TITLE
Add go to sites 1

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -254,11 +254,7 @@ sites:
       - esbbib.dk
       - www.esbbib.dk
     autogenerateRoutes: true
-<<<<<<< HEAD
-    <<: *go-release-pilot-sites
-=======
     <<: *x-defaults-with-go
->>>>>>> 0d8719b (move editors with GO onto the defaults with GO anchor)
   faaborg-midtfyn:
     name: "Faaborg-Midtfyn Bibliotekerne"
     description: "The library site for Faaborg-Midtfyn"
@@ -827,11 +823,7 @@ sites:
     secondary-domains:
       - bibliotek.skanderborg.dk
     autogenerateRoutes: true
-<<<<<<< HEAD
-    <<: *go-release-pilot-sites
-=======
     <<: *x-defaults-with-go
->>>>>>> 0d8719b (move editors with GO onto the defaults with GO anchor)
   skive:
     name: "Skive Bibliotek"
     description: "The library site for Skive"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR does a couple of things:

1. It makes a differentiation between sites that are GO pilots and have agreed to be labrats and those who just want GO
2. Adds two new [anchors](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/) to `sites.yaml`. One for editors who have or should have GO and one for webmasters who has or should have GO. 
3. It removes an anchor introduced for deploying a GO version for testing on a few specific sites
4. It adds GO to a new list of libraries, as reuested [here]([#DDF - Drift+ > GO-sites til 23. juni @ 💬](https://reload.zulipchat.com/#narrow/channel/435665-DDF---Drift.2B/topic/GO-sites.20til.2023.2E.20juni/near/525341947))


#### Should this be tested by the reviewer and how?
This should be read thorougly

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-380