### PR TITLE
Release Graphql cache-in-db hotfix 2025.26.1

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -80,7 +80,7 @@ sites:
     description: "Et site hvor bibliotekerne kan teste"
     importTranslationsCron: "0 * * * *"
     plan: webmaster
-    go-release: 2025.26.1
+    go-release: 2025.26.0
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
     <<: *webmasters-on-weekly-release-cycle
   # BNF site.


### PR DESCRIPTION
#### What does this PR do?
Pushes out a hot fix for problems with corrupt graphql cache

