### PR TITLE
Fix default setting for deployents

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -1075,10 +1075,10 @@ tasks:
           task: site:full-sync
           vars:
             SITE: "{{.ITEM}}"
-            SKIP_ENSURE_PROJECT: "{{.SKIP_ENSURE_PROJECT | default TRUE}}"
-            SKIP_CAPTURE_DEPLOY_KEY: "{{.SKIP_CAPTURE_DEPLOY_KEY | default TRUE}}"
-            SKIP_PROVISION: "{{.SKIP_PROVISION | default TRUE}}"
-            SKIP_FIRST_DEPLOYMENT: "{{.SKIP_FIRST_DEPLOYMENT | default TRUE}}"
+            SKIP_ENSURE_PROJECT: "{{.SKIP_ENSURE_PROJECT | default \"TRUE\"}}"
+            SKIP_CAPTURE_DEPLOY_KEY: "{{.SKIP_CAPTURE_DEPLOY_KEY | default \"TRUE\"}}"
+            SKIP_PROVISION: "{{.SKIP_PROVISION | default \"TRUE\"}}"
+            SKIP_FIRST_DEPLOYMENT: "{{.SKIP_FIRST_DEPLOYMENT | default \"TRUE\"}}"
             SKIP_REPO_SYNC: "{{.SKIP_REPO_SYNC}}"
             SKIP:
               sh: |


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Currently deployments with the sites:sync task will fail with the error `template: :1: function "TRUE" not defined`.

To address this we properly quote the `TRUE` string.

#### Should this be tested by the reviewer and how?

This will be a bit hard since we do not want to run more deployments.

#### Any specific requests for how the PR should be reviewed?


