### PR TITLE
add dependency to community chart

### DIFF
--- a/gitops/dplplat01/mariadb-test-prometheus-exporter/Chart.yaml
+++ b/gitops/dplplat01/mariadb-test-prometheus-exporter/Chart.yaml
@@ -1,3 +1,7 @@
 apiVersion: v2
 name: mariadb-test-prometheus-exporter
 version: 0.0.0
+dependencies:
+  - name: prometheus-mysql-exporter
+    version: 2.10.0
+    repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
I was missing the dependency to the Helm chart 