### PR TITLE
charts should go into a charts folder

### DIFF
--- a/.github/workflows/push-mariadb-helm-chart.yaml
+++ b/.github/workflows/push-mariadb-helm-chart.yaml
@@ -36,5 +36,5 @@ jobs:
           NAME=$(yq '.name' gitops/dplplat01/charts/mariadb/Chart.yaml)
           helm dependency update gitops/dplplat01/charts/mariadb || true
           helm package gitops/dplplat01/charts/mariadb
-          helm push $NAME-$VERSION.tgz oci://ghcr.io/danskernesdigitalebibliotek/dpl-platform/mariadb-chart
+          helm push $NAME-$VERSION.tgz oci://ghcr.io/danskernesdigitalebibliotek/dpl-platform/charts
 


### PR DESCRIPTION
Images are now the base packages and any charts should land in the charts folder or at least follow a convention of being named charts/someChart