### PR TITLE
Updating bnf site for staging testing

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -90,7 +90,7 @@ sites:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
     plan: webmaster
-    moduletest-dpl-cms-release: 2025.27.2
+    moduletest-dpl-cms-release: 2025.32.0
     # Use the webmaster plan to add a module-test site which acts as a server
     # for the staging environment.
     # The module-test site should use the next version while the production


### PR DESCRIPTION
According to the documentation:

"Set the value of moduletest-dpl-cms-release for bnf to the new version" https://danskernesdigitalebibliotek.github.io/dpl-docs/DPL-Platform/runbooks/how-release-a-new-version-for-approval-testing/#procedure-new-release-for-approval-testing
