### PR TITLE
Fix correct argument/parameter sequence

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -226,9 +226,9 @@ function syncEnvRepo {
   local primaryDomain="${8:-}"
   local secondaryDomains="${9:-}"
   local diskSize="${10:-}"
-  local goRelease="${11:-}"
-  local primaryGoSubDomain="${12:-}"
-  local secondaryGoSubDomains="${13:-}"
+  local primaryGoSubDomain="${11:-}"
+  local secondaryGoSubDomains="${12:-}"
+  local goRelease="${13:-}"
 
   if [[ -z $siteName ]]; then
       echo "Missing site name"

--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -76,14 +76,14 @@ function renderProfileTemplate {
   local primaryDomain=${8:-}
   # A space-seperated list of secondary domains (optional)
   local secondaryDomainsString=${9:-}
-  # The primary GO subdomain (optional)
-  local primaryGoSubDomain=${10:-}
-  # A space seperated list of secondary GO sub domains (optional)
-  local secondaryGoSubDomains=${11:-}
-  #GO release version
-  local GO_RELEASE=${12:-}
   # The desired size of the Persistent Volume
-  local diskSize=${13:-}
+  local diskSize=${10:-}
+  # The primary GO subdomain (optional)
+  local primaryGoSubDomain=${11:-}
+  # A space seperated list of secondary GO sub domains (optional)
+  local secondaryGoSubDomains=${12:-}
+  #GO release version
+  local GO_RELEASE=${13:-}
 
   PRIMARY_DOMAIN=""
 
@@ -225,8 +225,8 @@ function syncEnvRepo {
   local autogenerateRoutes="${7:-}"
   local primaryDomain="${8:-}"
   local secondaryDomains="${9:-}"
-  local goRelease="${10:-}"
-  local diskSize="${11:-}"
+  local diskSize="${10:-}"
+  local goRelease="${11:-}"
   local primaryGoSubDomain="${12:-}"
   local secondaryGoSubDomains="${13:-}"
 


### PR DESCRIPTION
This fixes moduletests thinking they should have a GO project. 
The reason: Mixed up sequence of arguments/parameters