### PR TITLE
adjust prometheus disk size

### DIFF
--- a/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
+++ b/infrastructure/environments/dplplat01/configuration/prometheus/prometheus-values.yaml
@@ -79,7 +79,7 @@ prometheus:
          resources:
            requests:
            # Setup a disk for holding the metrics.
-             storage: 500Gi
+             storage: 600Gi
 
     tolerations:
       - key: CriticalAddonsOnly


### PR DESCRIPTION
This gives prometheus an additional 100GB storage. This is a good measure because we are now ingesting data from more services (GO and databases). 
This size might have to increase in the future