### PR TITLE
increase innodb size by 100%

### DIFF
--- a/gitops/dplplat01/mariadb-10-6-22-production-1/templates/mariadb-server.template.yaml
+++ b/gitops/dplplat01/mariadb-10-6-22-production-1/templates/mariadb-server.template.yaml
@@ -44,7 +44,7 @@ spec:
     [mariadb]
     bind-address=*
     default_storage_engine=InnoDB
-    innodb_buffer_pool_size=12000MB
+    innodb_buffer_pool_size=24000MB
     innodb_autoinc_lock_mode=1
     binlog_format=row
     max_connections=1250


### PR DESCRIPTION
This increases the production database's InnoDB size from 12GB to 24GB. The change lands the InnoDB at ~35% of available RAM on the VM