### PR TITLE
Add moduletest reset to argo

### DIFF
--- a/gitops/dplplat01/argo-cd-resources/templates/projects/moduletest-reset.yaml
+++ b/gitops/dplplat01/argo-cd-resources/templates/projects/moduletest-reset.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: moduletest-reset
+spec:
+  destinations:
+  - name: in-cluster
+    namespace: moduletest-reset
+    server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  orphanedResources:
+    warn: true
+  sourceRepos:
+  - https://github.com/danskernesdigitalebibliotek/dpl-platform.git # git repository

--- a/gitops/dplplat01/argo-cd-resources/values.yaml
+++ b/gitops/dplplat01/argo-cd-resources/values.yaml
@@ -20,6 +20,11 @@ apps:
     namespace: harbor
     automated: false
 
+  - name: moduletest-reset
+    project: moduletest-reset
+    namespace: moduletest-reset
+    automated: false
+
   # Databases
   - name: mariadb-10-6-22-production-1
     project: databases

--- a/gitops/dplplat01/moduletest-reset/Chart.yaml
+++ b/gitops/dplplat01/moduletest-reset/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: moduletest-reset
+version: 0.0.1

--- a/gitops/dplplat01/moduletest-reset/templates/moduletest-reset-cronjob.template.yaml
+++ b/gitops/dplplat01/moduletest-reset/templates/moduletest-reset-cronjob.template.yaml
@@ -1,0 +1,87 @@
+# This manifest will fire up a customer Kubernetes Job in moduletest namepaces.
+# It will synchronize all files as well as the database from the corresponding main environment to the moduletest environment
+
+{{ range .Values.projects }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: moduletest-reset-{{ . }}
+spec:
+  schedule: "0 23 * * 3"  # Every Wednesday at 23:00
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 50400 # 14 hours leaving time to investigate failed jobs
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: moduletest-reset-container
+              image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset-job:mr-1.0.40
+              command:
+                - /bin/bash
+                - -c
+                - ./moduletest-reset-job.mjs {{ . }}
+              env:
+                - name: AZURE_DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: azure-database-host
+                      key: host
+          serviceAccountName: moduletest-reset-serviceaccount
+          tolerations:
+            - key: noderole.dplplatform
+              operator: Equal
+              value: prod
+              effect: NoSchedule
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: noderole.dplplatform
+                      operator: In
+                      values:
+                       - prod
+
+---
+{{ end }}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: moduletest-reset-serviceaccount
+  namespace: moduletest-reset
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: deployments-get-cluster-role
+  namespace: moduletest-reset
+rules:
+- apiGroups: [""]
+  resources: [ "namespaces", "pods", "pods/exec", "configmaps" ]
+  verbs: [ "get", "list", "create" ]
+- apiGroups: [ "apps", "configmaps" ]
+  resources: [ "deployments", "pods" ]
+  verbs: [ "get", "list" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-deployments-getter-binding
+subjects:
+- kind: ServiceAccount
+  name: moduletest-reset-serviceaccount
+  namespace: moduletest-reset
+roleRef:
+  kind: ClusterRole
+  name: deployments-get-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/gitops/dplplat01/moduletest-reset/values.yaml
+++ b/gitops/dplplat01/moduletest-reset/values.yaml
@@ -1,0 +1,16 @@
+projects:
+  - canary
+  - customizable-canary
+  - kobenhavn
+  - faxe
+  - albertslund
+  - aalborg
+  - aarhus
+  - ballerup
+  - herning
+  - odense
+  - roskilde
+  - silkeborg
+  - sonderborg
+  - sydslesvig
+  - taarnby


### PR DESCRIPTION
This PR moves the moduletest-reset'er into argo cd in it's current state.
The final goal is to have it added to a sort of default `Chart`. This however takes some tuning of the application which hasen't been done yet
