### PR TITLE
Deploy release 2025.33.1 to webmasters

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -10,7 +10,7 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.33.0"
   moduletest-dpl-cms-release: "2025.34.0"
-  go-release: 2025.33.0
+  go-release: 2025.33.1
 # Mounted Disk sizes
 x-disk-size-small: &disk-size-small
   diskSize: 10


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Deploy release 2025.33.1 to webmasters. This contains a fix that is already included in 2025.34.0.
