### PR TITLE
Clean up after moving ingress nginx

### DIFF
--- a/gitops/dplplat01/ingress-nginx/Chart.yaml
+++ b/gitops/dplplat01/ingress-nginx/Chart.yaml
@@ -1,4 +1,3 @@
-# https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
 apiVersion: v2
 name: ingress-nginx-controller
 version: 0.0.0

--- a/gitops/dplplat01/ingress-nginx/Chart.yaml
+++ b/gitops/dplplat01/ingress-nginx/Chart.yaml
@@ -1,3 +1,4 @@
+# https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
 apiVersion: v2
 name: ingress-nginx-controller
 version: 0.0.0

--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -295,18 +295,6 @@ tasks:
         - cm-verifier
         - kubectl get pods --namespace cert-manager
 
-    support:provision:ingress-nginx:
-      deps: [cluster:auth]
-      summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.
-      desc: Install and configure ingress-nginx
-      env:
-        INGRESS_IP:
-          sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".ingress_ip.value | select (.!=null)"
-        RESOURCE_GROUP:
-          sh: terraform -chdir={{.dir_infra}} output -json | jq --raw-output ".resourcegroup_name.value | select (.!=null)"
-      cmds:
-        - task/scripts/provision-ingress-nginx.sh
-
     support:provision:minio:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.
@@ -990,7 +978,6 @@ tasks:
         - task: support:provision:cert-manager
         - task: support:provision:grafana
         - task: support:provision:harbor
-        - task: support:provision:ingress-nginx
         - task: support:provision:k8up
         - task: support:provision:loki
         - task: support:provision:minio

--- a/infrastructure/environments/dplplat01/configuration/versions.env
+++ b/infrastructure/environments/dplplat01/configuration/versions.env
@@ -11,9 +11,6 @@ VERSION_GRAFANA=8.1.0
 # https://artifacthub.io/packages/helm/harbor/harbor
 VERSION_HARBOR=1.15.2
 
-# https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
-VERSION_INGRESS_NGINX=4.9.1
-
 # https://artifacthub.io/packages/helm/appuio/k8up
 # appVersion 1.2.0
 # NOTICE - lagoon is currently only compatible with version 1.x of k8up


### PR DESCRIPTION
This PR removes Tasks and Task related information on how to manage Ingress-Nginx as it has now been moved into Argo CD and will now be managed through Argo. 

The PR is missing a modification to the runbook on how to upgrade Ingress-Nginx