### PR TITLE
Deploy 2025.36.1 to production/webmaster moduletest sites

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,14 +2,14 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: "2025.36.0"
-  go-release: 2025.36.0
+  dpl-cms-release: "2025.36.1"
+  go-release: 2025.36.1
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.34.0"
-  moduletest-dpl-cms-release: "2025.36.0"
+  moduletest-dpl-cms-release: "2025.36.1"
   go-release: 2025.34.1
 # Mounted Disk sizes
 x-disk-size-small: &disk-size-small
@@ -27,14 +27,14 @@ sites:
     description: "A site for developers and operators to test on"
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
-    dpl-cms-release: 2025.36.0
+    dpl-cms-release: 2025.36.1
     plan: webmaster
-    go-release: 2025.36.0
+    go-release: 2025.36.1
     primary-domain: canary.dplplat01.dpl.reload.dk
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
     # has been updated to use the primary domain.
     autogenerateRoutes: true
-    moduletest-dpl-cms-release: 2025.36.0
+    moduletest-dpl-cms-release: 2025.36.1
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhuA0K7CNvRoe+Xx7RaXG4+a8KcSpzuWn+G4sUPzNWx"
     <<: *disk-size-small
   customizable-canary:
@@ -43,9 +43,9 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: 2025.36.0
-    moduletest-dpl-cms-release: 2025.36.0
-    go-release: 2025.36.0
+    dpl-cms-release: 2025.36.1
+    moduletest-dpl-cms-release: 2025.36.1
+    go-release: 2025.36.1
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
     <<: *disk-size-small
   staging:
@@ -84,7 +84,7 @@ sites:
     description: "Et site hvor bibliotekerne kan teste"
     importTranslationsCron: "0 * * * *"
     plan: webmaster
-    go-release: 2025.36.0
+    go-release: 2025.36.1
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
     << : [ *webmasters-on-weekly-release-cycle, *disk-size-small ]
   # BNF site.


### PR DESCRIPTION
As this is a hotfix, we don't touch webmaster production sites.

