### PR TITLE
Pin kerteminde odense

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -733,7 +733,15 @@ sites:
     secondary-domains:
       - odensebib.dk
     autogenerateRoutes: true
-    <<: [ *webmasters-on-weekly-release-cycle, *disk-size-medium ]
+    # Pin down to specific version until we figure out what's making
+    # the updata fail. When ready, revert the commit that added this.
+    releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+    releaseImageName: dpl-cms-source
+    dpl-cms-release: 2025.36.1
+    moduletest-dpl-cms-release: 2025.36.1
+    go-release: 2025.36.2
+    php-version: 8.1
+    <<: [ *disk-size-medium ]
   odsherred:
     name: "Odsherred Bibliotek og Kulturhuse"
     description: "The library site for Odsherred"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Pin down Kerteminde and Odense to avoid accidentally deploying and update that munges the sites.

These should be revertable when DDFDRIFT-484 is fixed.