### PR TITLE
Deploy Go hotfix 2025.38.1 and 2025.36.3 to production/webmaster

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -3,7 +3,7 @@ x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
   dpl-cms-release: 2025.38.0
-  go-release: 2025.38.0
+  go-release: 2025.38.1
   php-version: 8.3
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   #This release cycle releases the newest release, which has been tested on webmaster moduletests in the previous week, on to production
@@ -11,7 +11,7 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   releaseImageName: dpl-cms-source
   dpl-cms-release: "2025.36.1"
   moduletest-dpl-cms-release: 2025.38.0
-  go-release: 2025.36.2
+  go-release: 2025.36.3
   # TODO: Update to 8.3 during release in week 40
   php-version: 8.1
   moduletest-php-version: 8.3
@@ -34,7 +34,7 @@ sites:
     plan: webmaster
     dpl-cms-release: 2025.38.0
     moduletest-dpl-cms-release: 2025.38.0
-    go-release: 2025.38.0
+    go-release: 2025.38.1
     php-version: 8.3
     moduletest-php-version: 8.3
     diskSize: 11
@@ -51,7 +51,7 @@ sites:
     plan: webmaster
     dpl-cms-release: 2025.38.0
     moduletest-dpl-cms-release: 2025.38.0
-    go-release: 2025.38.0
+    go-release: 2025.38.1
     php-version: 8.3
     moduletest-php-version: 8.3
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
@@ -95,7 +95,7 @@ sites:
     description: "Et site hvor bibliotekerne kan teste"
     importTranslationsCron: "0 * * * *"
     plan: webmaster
-    go-release: 2025.38.0
+    go-release: 2025.38.1
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
     << : [ *webmasters-on-weekly-release-cycle, *disk-size-small ]
   # BNF site.
@@ -571,7 +571,7 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     dpl-cms-release: 2025.36.1
-    go-release: 2025.38.0
+    go-release: 2025.38.1
     php-version: 8.1
     << : [ *disk-size-medium ]
   kobenhavn:
@@ -739,7 +739,7 @@ sites:
     releaseImageName: dpl-cms-source
     dpl-cms-release: 2025.36.1
     moduletest-dpl-cms-release: 2025.36.1
-    go-release: 2025.36.2
+    go-release: 2025.36.3
     php-version: 8.1
     <<: [ *disk-size-medium ]
   odsherred:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Update all Go sites with hotfix.