### PR TITLE
Update default values with default chart

### DIFF
--- a/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
@@ -10,6 +10,7 @@ s3FilesAccessKeyID: $LAGOON_FILES_ACCESS_KEY
 s3FilesBucket: $LAGOON_FILES_BUCKET
 s3FilesHost: $LAGOON_FILES_API_URL
 s3FilesSecretAccessKey: $LAGOON_FILES_SECRET_KEY
+registry: none.com
 
 # These values are optional.
 # overwriteActiveStandbyTaskImage:
@@ -398,7 +399,7 @@ keycloakDB:
                   - system
 
 broker:
-  replicaCount: 1
+  replicaCount: 3
   image:
     repository: uselagoon/broker
     pullPolicy: Always

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-core-values.template.yaml
@@ -1,45 +1,119 @@
+# These values must be set on install, as they don't have sensible defaults.
+
+harborAdminPassword: "$HARBOR_ADMIN_PASS"
 elasticsearchURL: none
 harborURL: https://habor.lagoon.dplplat01.dpl.reload.dk
-harborAdminPassword: "$HARBOR_ADMIN_PASS"
-keycloakAdminPassword: "$KEYCLOAK_ADMIN_PASS"
 kibanaURL: none
-logsDBAdminPassword: ke2ue1Chae
+s3BAASSecretAccessKey: $BAAS_STORAGE_SECRET_KEY
+s3BAASAccessKeyID: $BAAS_STORAGE_ACCESS_KEY
 s3FilesAccessKeyID: $LAGOON_FILES_ACCESS_KEY
-s3FilesSecretAccessKey: $LAGOON_FILES_SECRET_KEY
 s3FilesBucket: $LAGOON_FILES_BUCKET
 s3FilesHost: $LAGOON_FILES_API_URL
-s3BAASAccessKeyID: $BAAS_STORAGE_ACCESS_KEY
-s3BAASSecretAccessKey: $BAAS_STORAGE_SECRET_KEY
-registry: none.com
+s3FilesSecretAccessKey: $LAGOON_FILES_SECRET_KEY
 
-# Disabled services:
-logs2email:
-  enabled: false
-logs2microsoftteams:
-  enabled: false
-logs2rocketchat:
-  enabled: false
-logs2slack:
-  enabled: false
-logs2webhook:
-  enabled: false
+# These values are optional.
+# overwriteActiveStandbyTaskImage:
 
-#Deployments
-actionsHandler:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+# appspecific discovery.json settings
+# This should point to the publicly accessible ssh endpoint as a schema-less
+# URI (either domain or IP) for the ssh-token (or fallback ssh) service
+# e.g. ssh-token.example.com, ssh.example.com or 192.168.0.100
+# The port will be read from the sshToken (or ssh) port value
+# sshTokenEndpoint:
+
+# These values are optional depending on the services Lagoon is integrated with
+# in your environment.
+
+# gitlabAPIToken:
+# gitlabAPIURL:
+# bitbucketAPIToken:
+# bitbucketAPIURL:
+# s3Region:
+
+# These values may be set on install, otherwise the chart tries to guess
+# sensible defaults.
+
+# keycloakFrontEndURL: https://keycloak.example.com
+# lagoonAPIURL: https://api.example.com/graphql
+# lagoonUIURL: https://ui.example.com
+# lagoonWebhookURL: https://webhook-handler.example.com
+
+# These values are randomly generated on install if not otherwise defined.
+
+# apiDBPassword:
+# jwtSecret:
+keycloakAdminPassword: "$KEYCLOAK_ADMIN_PASS"
+# keycloakAPIClientSecret:
+# keycloakAuthServerClientSecret:
+# keycloakDBPassword:
+# keycloakLagoonAdminPassword:
+logsDBAdminPassword: ke2ue1Chae
+# rabbitMQPassword:
+# redisPassword:
+# k8upBackupBucketName:
+
+# This value is set to match jwtSecret on existing installs if not defined.
+# It should only ever be set here for backwards compatibility.
+
+# projectSeed:
+
+# These values are the chart defaults, but can be overridden.
+imagePullSecrets: []
+
+rabbitMQUsername: lagoon
+
+k8upS3Endpoint: ""
+
+keycloakAdminUser: admin
+# this is required if email sending is to be enabled in keycloak
+# keycloakAdminEmail: admin@example.com
+
+buildDeployImage:
+  edge:
+    enabled: false
+
+# Set to an empty string to support Harbor v1.x.x
+harborAPIVersion: v2.0
+
+# this default podSecurityContext is set for all services and can be overridden
+# on the service level.
+podSecurityContext:
+  fsGroup: 10001
+  runAsGroup: 0
+  runAsUser: 10000
+
+# Set the default ingressClass for the exposed lagoon-core services
+# it can be overridden per-service if needed via ingress.ingressClassName
+# Note that this is the Class, not the IngressName
+# defaultIngressClassName: nginx
+
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set it falls back to chart appVersion.
+imageTag: ""
+
+# This value is false by default, which means that Developers can SSH to
+# Development environments as per the Lagoon documentation
+# (https://docs.lagoon.sh/administering-lagoon/rbac/#developer).
+# Set this to true to:
+# * block Developers from SSH access to Lagoon environments; and
+# * stop Developers from getting a redirect message when trying to SSH into the
+#   ssh-token service.
+# blockDeveloperSSH: false
+
+# the following services are part of the lagoon-core chart
 
 api:
+  replicaCount: 2
+  image:
+    repository: uselagoon/api
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  service:
+    type: ClusterIP
+    port: 80
+
   ingress:
     enabled: true
     annotations:
@@ -54,6 +128,91 @@ api:
       - secretName: api-tls
         hosts:
           - api.lagoon.dplplat01.dpl.reload.dk
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "500m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+apiDB:
+  image:
+    repository: uselagoon/api-db
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  service:
+    type: ClusterIP
+    port: 3306
+
+  podAnnotations:
+    appuio.ch/backupcommand: >
+      /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines
+      --quick --add-locks --no-autocommit --single-transaction --all-databases"
+    backup.appuio.ch/file-extension: .api-db.sql
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  storageSize: 128Gi
+
+  terminationGracePeriodSeconds: 30
+
+  startupProbe:
+    # 60*10s period = 10 minutes
+    failureThreshold: 60
+    exec:
+      command:
+      - test
+      - -f
+      - /tmp/mariadb-init-complete
+
+  livenessProbe:
+    exec:
+      command:
+      - mysqladmin
+      - --connect-timeout=4
+      - ping
+
+  readinessProbe:
+    exec:
+      command:
+      - /usr/share/container-scripts/mysql/readiness-probe.sh
+
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -68,34 +227,32 @@ api:
                   - system
 
 apiRedis:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+  image:
+    repository: uselagoon/api-redis
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
 
-authServer:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+  podAnnotations: {}
 
-logs2notifications:
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  persistence:
+    enabled: false
+    size: 100Mi
+
+  service:
+    type: ClusterIP
+    port: 6379
+
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -110,6 +267,48 @@ logs2notifications:
                   - system
 
 keycloak:
+  # keycloak realm and email settings configuration
+  realmSettings:
+    enabled: false
+    # the full list of config settings is available TODO
+    options:
+      resetPasswordAllowed: true
+      rememberMe: true
+  email:
+    enabled: false
+    settings:
+      host: mailhog
+      port: '1025'
+      from: lagoon@example.com
+      fromDisplayName: Lagoon
+      replyTo: lagoon@example.com
+      ssl: 'false'
+      starttls: 'false'
+      auth: 'false'
+
+  replicaCount: 1
+  image:
+    repository: uselagoon/keycloak
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: ClusterIP
+    port: 8080
+
   ingress:
     enabled: true
     annotations:
@@ -123,6 +322,7 @@ keycloak:
       - secretName: keycloak-tls
         hosts:
           - keycloak.lagoon.dplplat01.dpl.reload.dk
+
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -136,161 +336,54 @@ keycloak:
                 values:
                   - system
 
-webhookHandler:
-  ingress:
-    enabled: true
-    annotations:
-      kubernetes.io/tls-acme: "true"
-      kubernetes.io/ingress.class: "nginx"
-    hosts:
-    - host: webhookhandler.lagoon.dplplat01.dpl.reload.dk
-      paths:
-      - /
-    tls:
-      - secretName: webhookhandler-tls
-        hosts:
-          - webhookhandler.lagoon.dplplat01.dpl.reload.dk
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+keycloakDB:
+  replicaCount: 1
+  image:
+    repository: uselagoon/keycloak-db
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
 
-webhooks2tasks:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
-
-ui:
-  ingress:
-    enabled: true
-    annotations:
-      kubernetes.io/tls-acme: "true"
-      kubernetes.io/ingress.class: "nginx"
-    hosts:
-    - host: ui.lagoon.dplplat01.dpl.reload.dk
-      paths:
-      - /
-    tls:
-      - secretName: ui-tls
-        hosts:
-          - ui.lagoon.dplplat01.dpl.reload.dk
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
-
-backupHandler:
-  ingress:
-    enabled: true
-    annotations:
-      kubernetes.io/tls-acme: "true"
-      kubernetes.io/ingress.class: "nginx"
-    hosts:
-    - host: backuphandler.lagoon.dplplat01.dpl.reload.dk
-      paths:
-      - /
-    tls:
-      - secretName: backuphandler-tls
-        hosts:
-          - backuphandler.lagoon.dplplat01.dpl.reload.dk
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
-
-drushAlias:
-  ingress:
-    enabled: true
-    annotations:
-      kubernetes.io/tls-acme: "true"
-      kubernetes.io/ingress.class: "nginx"
-    hosts:
-    - host: drushalias.lagoon.dplplat01.dpl.reload.dk
-      paths:
-      - /
-    tls:
-      - secretName: drushalias-tls
-        hosts:
-          - drushalias.lagoon.dplplat01.dpl.reload.dk
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
-
-ssh:
   service:
-    type: LoadBalancer
-    port: 22
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+    type: ClusterIP
+    port: 3306
 
-workflows:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+  podAnnotations:
+    appuio.ch/backupcommand: >
+      /bin/sh -c "mysqldump --max-allowed-packet=500M --events --routines
+      --quick --add-locks --no-autocommit --single-transaction --all-databases"
+    backup.appuio.ch/file-extension: .keycloak-db.sql
 
-# Statfulsets
-apiDB:
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "100m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  terminationGracePeriodSeconds: 30
+
+  startupProbe:
+    # 60*10s period = 10 minutes
+    failureThreshold: 60
+    tcpSocket:
+      port: mariadb
+
+  livenessProbe:
+    exec:
+      command:
+      - mysqladmin
+      - --connect-timeout=4
+      - ping
+
+  readinessProbe:
+    exec:
+      command:
+      - /usr/share/container-scripts/mysql/readiness-probe.sh
+
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -305,8 +398,55 @@ apiDB:
                   - system
 
 broker:
+  replicaCount: 1
+  image:
+    repository: uselagoon/broker
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  service:
+    type: ClusterIP
+    ports:
+      epmd: 4369
+      amqp: 5672
+      http: 15672
+      metrics: 15692
+    amqpExternal:
+      enabled: false
+      type: LoadBalancer
+      port: 5672
+
   serviceMonitor:
     enabled: false
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  serviceAccount:
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name: ""
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
   ingress:
     enabled: true
     annotations:
@@ -333,7 +473,37 @@ broker:
                 values:
                   - system
 
-keycloakDB:
+authServer:
+  replicaCount: 2
+  image:
+    repository: uselagoon/auth-server
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -346,3 +516,673 @@ keycloakDB:
                 operator: In
                 values:
                   - system
+
+webhooks2tasks:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/webhooks2tasks
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+webhookHandler:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/webhook-handler
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      kubernetes.io/ingress.class: "nginx"
+    hosts:
+    - host: webhookhandler.lagoon.dplplat01.dpl.reload.dk
+      paths:
+      - /
+    tls:
+      - secretName: webhookhandler-tls
+        hosts:
+          - webhookhandler.lagoon.dplplat01.dpl.reload.dk
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+ui:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/ui
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      kubernetes.io/ingress.class: "nginx"
+    hosts:
+    - host: ui.lagoon.dplplat01.dpl.reload.dk
+      paths:
+      - /
+    tls:
+      - secretName: ui-tls
+        hosts:
+          - ui.lagoon.dplplat01.dpl.reload.dk
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+actionsHandler:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/actions-handler
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+backupHandler:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/backup-handler
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      kubernetes.io/ingress.class: "nginx"
+    hosts:
+    - host: backuphandler.lagoon.dplplat01.dpl.reload.dk
+      paths:
+      - /
+    tls:
+      - secretName: backuphandler-tls
+        hosts:
+          - backuphandler.lagoon.dplplat01.dpl.reload.dk
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+insightsHandler:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: uselagoon/insights-handler
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.0.4"
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  trivy:
+    enabled: false
+    image:
+      repository: aquasec/trivy
+      tag: 0.48.0
+    service:
+      type: ClusterIP
+      port: 4954
+
+logs2notifications:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/logs2notifications
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  logs2slack:
+    disabled: true
+  logs2rocketchat:
+    disabled: true
+  logs2microsoftteams:
+    disabled: true
+  logs2email:
+    disabled: true
+  logs2webhooks:
+    disabled: true
+  logs2s3:
+    disabled: false
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+drushAlias:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/drush-alias
+    pullPolicy: Always
+    # Overrides the image tag whose default is "latest".
+    tag: "v3.1.0"
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      kubernetes.io/ingress.class: "nginx"
+    hosts:
+    - host: drushalias.lagoon.dplplat01.dpl.reload.dk
+      paths:
+      - /
+    tls:
+      - secretName: drushalias-tls
+        hosts:
+          - drushalias.lagoon.dplplat01.dpl.reload.dk
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+ssh:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/ssh
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "500m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  service:
+    type: LoadBalancer
+    port: 22
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+  autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
+  
+
+workflows:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: uselagoon/workflows
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "16Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
+nats:
+  enabled: false
+  # inject additional config
+  additionalVolumes:
+  - name: lagoon-core-nats-tls
+    secret:
+      secretName: lagoon-core-nats-tls
+  additionalVolumeMounts:
+  - name: lagoon-core-nats-tls
+    mountPath: /etc/lagoon-core-nats-tls
+  nats:
+    config:
+    - name: lagoon-core
+      secret:
+        secretName: lagoon-core-nats-conf
+  cluster:
+    enabled: true
+    name: lagoon-core
+    # internal cluster IPs are not routable, so don't advertise them
+    noAdvertise: true
+  natsbox:
+    enabled: false
+  # to connect to nats, pods must have the right label
+  networkPolicy:
+    enabled: true
+    allowExternal: false
+    # allow inbound leaf connections
+    extraIngress:
+    - ports:
+      - port: 7422
+        protocol: TCP
+
+natsService:
+  # this service is enabled via nats.enabled
+  type: LoadBalancer
+  leafnodes:
+    port: 7422
+
+natsConfig:
+  users:
+    lagoonRemote: []
+    # Remote cluster  credentials and the account they have access to are
+    # specified here.
+    #
+    # - user: ...
+    #   password: ...
+  tls: {}
+    # If the lagoon-core-nats-tls secret should be created by the lagoon-core
+    # chart, certificate values can be specified directly in secretData.
+    # Configuring TLS this way also allows specifying a custom ca.crt.
+    #
+    # secretData:
+    #   ca.crt: |
+    #     ...
+    #   server.crt: |
+    #     ...
+    #   server.key: |
+    #     ...
+    #
+    # If the TLS secret is created outside the lagoon-core chart, it should be
+    # named lagoon-core-nats-tls. This secret should contain fields tls.crt and
+    # tls.key, and the certificate should be issued by a public authority.
+
+sshPortalAPI:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.30.1"
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  serviceAccount:
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name: ""
+
+  serviceMonitor:
+    enabled: true
+
+  service:
+    type: ClusterIP
+    ports:
+      metrics: 9911
+
+opensearchSync:
+  enabled: false
+  image:
+    repository: ghcr.io/uselagoon/lagoon-opensearch-sync
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.7.1"
+
+  # debug logging toggle
+  debug: false
+
+  # root certificate for the server certificate presented by opensearch
+  opensearchCACertificate: |
+  # -----BEGIN CERTIFICATE-----
+  # ...
+  # -----END CERTIFICATE-----
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+sshToken:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-token
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.30.1"
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources:
+    requests:
+      memory: "8Mi"
+      cpu: "10m"
+
+  additionalEnvs:
+  #   FOO: Bar
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  serviceMonitor:
+    enabled: true
+
+  service:
+    type: LoadBalancer
+    ports:
+      sshserver: 22
+
+  metricsService:
+    type: ClusterIP
+    ports:
+      metrics: 9948
+
+  # host keys, PEM encoded
+  hostKeys:
+    ecdsa: ""
+    ed25519: ""
+    rsa: ""

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -1,5 +1,191 @@
+# Default values for lagoon-remote.
+
+# global values which can affect subcharts
+global:
+  # set to true to enable openshift support
+  openshift: false
+  rabbitMQUsername: ""
+  rabbitMQPassword: ""
+  rabbitMQHostname: ""
+
+imagePullSecrets: []
+
+logsDispatcherHost: |-
+  lagoon-logging-logs-dispatcher.lagoon-logging.svc.cluster.local
+
+# If this value is set, it will create an `mxout` ExternalName service in the
+# deployed namespace pointing at the given host. This service can then be used
+# by workloads running in-cluster to connect to a platform-provided mailserver.
+mxoutHost: ""
+
+# this default image tag is set for all services and can be overridden
+# on the service level, if not set it uses chart appVersion
+imageTag: ""
+
+dockerHost:
+  image:
+    repository: uselagoon/docker-host
+    pullPolicy: Always
+    # Overrides the image tag whose default is "latest".
+    tag: "v3.3.0"
+
+  name: docker-host
+
+  registry: registry.lagoon.svc:5000
+
+  repositoryToUpdate: amazeeio|lagoon
+
+  pruneImagesUntil: 168h
+
+  replicaCount: 1
+
+  ## proxy configuration
+  # httpProxy: ""
+  # httpsProxy: ""
+  # noProxy: ""
+
+  # add extra environment variables if required
+  extraEnvs:
+
+  storage:
+    create: true
+    size: 750Gi
+    # className sets the storageClassName for the docker-host PVC. This is
+    # useful if the docker-host requires a specific storage class for features
+    # such as increased IOPS.
+    #
+    # WARNING: On platforms such as AKS not all storage volume classes can be
+    # bound to all node types. So if you configure a storage class that can't
+    # be bound to any nodes in the cluster it will cause the docker-host pod to
+    # fail to schedule. For example AKS requires Premium Storage suport on the
+    # node for the managed-premium storage class.
+    #
+    # If className is not defined the chart will not set any specify storage
+    # class on the PVC, effectively falling back to the cluster default.
+    #
+    # className: managed-premium
+
+  networkPolicy:
+    # Specifies whether the docker-host network policy should be enabled
+    enabled: true
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name:
+
+  podSecurityContext: {}
+
+  securityContext:
+    privileged: true
+    seLinuxOptions:
+      # Ensures selinux relabeling is disabled, this would case the container never to start
+      # as there can be so many files in the persistent storage
+      type: spc_t
+
+  resources: {}
+
+  service:
+    type: ClusterIP
+    port: 2375
+
+  tolerations:
+  - key: noderole.dplplatform
+    operator: Equal
+    value: build
+    effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: noderole.dplplatform
+              operator: In
+              values:
+                - build
+
+# sshCore creates a restricted, non-expiring ServiceAccount token for use by
+# lagoon-core.
+sshCore:
+  enabled: true
+  serviceAccount:
+    annotations: {}
+    # The name of the service account to use.
+    # If not set, a name is generated using the fullname
+    # template
+    name: ""
+
+# sshPortal is an optional service providing low-latency SSH connectivity to
+# Lagoon environments.
+sshPortal:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/uselagoon/lagoon-ssh-portal/ssh-portal
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.30.1"
+
+  service:
+    type: LoadBalancer
+    ports:
+      sshserver: 22
+    annotations: {}
+
+  metricsService:
+    type: ClusterIP
+    ports:
+      metrics: 9912
+
+  podAnnotations: {}
+
+  securityContext: {}
+
+  resources: {}
+
+  additionalEnvs: {}
+
+  serviceAccount:
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name: ""
+
+  serviceMonitor:
+    enabled: true
+
+  # host keys, PEM encoded
+  hostKeys:
+    ecdsa: ""
+    ed25519: ""
+    rsa: ""
+
+# This subchart is disabled by default until this build-deploy type is in
+# widespread use.
 lagoon-build-deploy:
   enabled: true
+  # these values are used by the lagoon-build-deploy controller and do not have
+  # sensible defaults.
+  # lagoonTargetName:
+  taskSSHHost: "$SSH_LOADBALANCER_IP"
+  taskSSHPort: "22"
+  taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
+  # lagoonTokenHost: ""
+  # lagoonTokenPort: ""
+  # lagoonAPIHost: ""
+  # sshPortalHost: ""
+  # sshPortalPort: ""
+  rabbitMQUsername: "lagoon"
+  rabbitMQPassword: "$RABBITMQ_PASS"
+  rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"
+  lagoonTargetName: "lagoon"
+  lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
+  # See the parent chart for the full range of values that can be passed here to control builds
+  # https://github.com/uselagoon/lagoon-charts/blob/main/charts/lagoon-build-deploy/values.yaml
   extraArgs:
     - "--enable-harbor=true"
     # TODO template
@@ -9,14 +195,7 @@ lagoon-build-deploy:
     - "--harbor-password=$HARBOR_ADMIN_PASS"
     - "--enable-qos"
     - "--qos-max-builds=8"
-  rabbitMQUsername: "lagoon"
-  rabbitMQPassword: "$RABBITMQ_PASS"
-  rabbitMQHostname: "lagoon-core-broker.lagoon-core.svc.cluster.local"
-  lagoonTargetName: "lagoon"
-  taskSSHHost: "$SSH_LOADBALANCER_IP"
-  taskSSHPort: "22"
-  taskAPIHost: "api.lagoon.dplplat01.dpl.reload.dk"
-  lagoonFeatureFlagDefaultRootlessWorkload: "enabled"
+
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -30,12 +209,16 @@ lagoon-build-deploy:
                 values:
                   - system
 
-
-sshCore:
-  enabled: true
-
+# dbaas-operator provisions database-as-a-service accounts for projects.
+# Example provider configuration can be found in the dbaas-operator values.yaml
+# https://github.com/amazeeio/charts/blob/main/charts/dbaas-operator/values.yaml
+# This subchart is disabled by default for legacy reasons. It will be enabled
+# by default in future as this is a core Lagoon feature.
 dbaas-operator:
   enabled: true
+  enableMariaDBProviders: true
+  enableMongoDBProviders: true
+  enablePostreSQLProviders: true
 
   mariadbProviders:
     production:
@@ -68,32 +251,174 @@ dbaas-operator:
                 values:
                   - system
 
-dockerHost:
-  tolerations:
-  - key: noderole.dplplatform
-    operator: Equal
-    value: build
-    effect: NoSchedule
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-            - key: noderole.dplplatform
-              operator: In
-              values:
-                - build
 
-dioscuri:
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: noderole.dplplatform
-                operator: In
-                values:
-                  - system
+# if you are using the dbaas-operator in a different release, you can define the http endpoint to use here
+# setting this will always override whatever `dbaas-operator` would set, useful if you want to target a different endpoint
+dbaasHTTPEndpoint: ""
+
+# lagoon-insights-remote:
+#   enabled: false
+  # burnAfterReading: false
+
+insightsRemote:
+  enabled: false
+  # sets insights configMaps to be removed after being processed
+  burnAfterReading: true
+
+  replicaCount: 1
+
+  # This is the secret used to sign JWT's injected into environments
+  # This shouldn't need to be changed in most circumstances - here for completion
+  # insightsTokenSecret: ""
+
+  image:
+    repository: uselagoon/insights-remote
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "v0.0.8"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  # service:
+  #   type: ClusterIP
+  #   port: 80
+  # ingress:
+  #   enabled: false
+  #   className: ""
+  #   annotations: {}
+  #     # kubernetes.io/ingress.class: nginx
+  #     # kubernetes.io/tls-acme: "true"
+  #   hosts:
+  #     - host: chart-example.local
+  #       paths:
+  #         - path: /
+  #           pathType: ImplementationSpecific
+  #   tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  service:
+    type: ClusterIP
+    port: 80
+
+
+# the nats chart is a subchart which is configured for use by lagoon-remote
+nats:
+  enabled: false
+  # inject additional config
+  additionalVolumes:
+  - name: lagoon-remote-nats-tls
+    secret:
+      secretName: lagoon-remote-nats-tls
+  additionalVolumeMounts:
+  - name: lagoon-remote-nats-tls
+    mountPath: /etc/lagoon-remote-nats-tls
+  nats:
+    config:
+    - name: lagoon-remote
+      secret:
+        secretName: lagoon-remote-nats-conf
+  cluster:
+    enabled: true
+    name: lagoon-remote
+    # internal cluster IPs are not routable, so don't advertise them
+    noAdvertise: true
+  natsbox:
+    enabled: false
+  # to connect to nats, pods must have the right label
+  networkPolicy:
+    enabled: true
+    allowExternal: false
+    # allow outbound leaf connection
+    extraEgress:
+    - ports:
+      - port: 7422
+        protocol: TCP
+
+# Configuration for the nats subchart
+natsConfig:
+  # coreURL format nats://<username>:<password>@<host>:7422
+  coreURL: ""
+  tls: {}
+    # If the lagoon-remote-nats-tls secret should be created by the
+    # lagoon-remote chart, certificate values can be specified directly in
+    # secretData. Configuring TLS this way also allows specifying a custom
+    # ca.crt.
+    #
+    # secretData:
+    #   ca.crt: |
+    #     ...
+    #   client.crt: |
+    #     ...
+    #   client.key: |
+    #     ...
+    #
+    # If the TLS secret is created outside the lagoon-remote chart, it should
+    # be named lagoon-remote-nats-tls. This secret should contain fields
+    # tls.crt and tls.key, and the certificate should be issued by a public
+    # authority.
+
+storageCalculator:
+  enabled: false
+  # cronjob: 5 */12 * * *
+  # ignoreRegex: "solr|redis"
+  serviceAccount:
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template
+    name:
+
+  image:
+    repository: uselagoon/remote-calculator
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: v0.2.3

--- a/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
+++ b/infrastructure/environments/dplplat01/lagoon/lagoon-remote-values.template.yaml
@@ -209,6 +209,23 @@ lagoon-build-deploy:
                 values:
                   - system
 
+# dioscuri is the operator which implements Lagoon active-standby.
+# This subchart is enabled by default as this is a core Lagoon feature.
+dioscuri:
+  enabled: true
+  tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: noderole.dplplatform
+                operator: In
+                values:
+                  - system
+
 # dbaas-operator provisions database-as-a-service accounts for projects.
 # Example provider configuration can be found in the dbaas-operator values.yaml
 # https://github.com/amazeeio/charts/blob/main/charts/dbaas-operator/values.yaml


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This PR consolidates the lagoon-remote and lagoon-core default values files with the standard values and standard structure provided with their respective charts.

#### Should this be tested by the reviewer and how?
You can run `DIFF=1 task lagoon:provision:remote` and `DIFF=1 task lagoon:provision:core` to see that the diffs are appropriate to what is currently running in cluster.

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/464?selectedIssue=DDFDRIFT-202