### PR TITLE
Deploy 2025.40.0 to staging

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -63,11 +63,10 @@ sites:
     releaseImageName: dpl-cms-source
     # Remember to update bnf.moduletest-dpl-cms-release to the same release
     # to make client and server use the same version.
-    dpl-cms-release: 2025.38.0
-    moduletest-dpl-cms-release: 2025.38.0
-    go-release: 2025.38.1
+    dpl-cms-release: 2025.40.0
+    moduletest-dpl-cms-release: 2025.40.0
+    go-release: 2025.40.0
     php-version: 8.3
-    moduletest-php-version: 8.3
     plan: webmaster
     primary-domain: staging.dplplat01.dpl.reload.dk
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
@@ -103,9 +102,7 @@ sites:
     name: "Bibliotekernes Nationale Formidling"
     description: "The BNF content sharing site"
     plan: webmaster
-    # 2025.38.0 needs PHP 8.3, this can be removed again when x-defaults is upgraded.
-    moduletest-php-version: 8.3
-    moduletest-dpl-cms-release: 2025.38.0
+    moduletest-dpl-cms-release: 2025.40.0
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICTmMC/cUI3U3QloX6aAdN7g0EU42J0fwA9aO7UJOzx9
     primary-domain: delingstjenesten.dk
     secondary-domains:


### PR DESCRIPTION
Deploy 2025.40.0 to staging and bnf moduletest. It has been applied.

Remove `moduletest-php-version` from staging, as both main and moduletest now needs 8.3 and are covered by the `php-version`.

Remvoe the same from bnf as `x-defaults` defines the proper version for both branches now.