### PR TITLE
When resetting db drop it first

### DIFF
--- a/gitops/dplplat01/moduletest-reset/templates/moduletest-reset-cronjob.yaml
+++ b/gitops/dplplat01/moduletest-reset/templates/moduletest-reset-cronjob.yaml
@@ -73,7 +73,7 @@ rules:
   resources: [ "namespaces", "pods", "pods/exec", "configmaps" ]
   verbs: [ "get", "list", "create" ]
 - apiGroups: [ "apps", "configmaps" ]
-  resources: [ "deployments", "pods" ]
+  resources: [ "deployments", "pods", "services" ]
   verbs: [ "get", "list" ]
 
 ---

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -104,7 +104,7 @@ async function importMainDumpIntoModuletestDatabase(databaseConnectionInfo, proj
   } = databaseConnectionInfo;
 
   try {
-    await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "mariadb --user=${databaseUser} --host=${databaseHost} --password=${databasePassword} ${databaseName} < /tmp/${projectName}-dump.sql"`
+    await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush drop && mariadb --user=${databaseUser} --host=${databaseHost} --password=${databasePassword} ${databaseName} < /tmp/${projectName}-dump.sql"`
   } catch(error) {
     echo(`Failed to import dump into ${projectName}-moduletest's database`, error.stderr);
     throw Error(`Failed to import dump into ${projectName}-moduletest's database`, { cause: error });

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -5,8 +5,6 @@ if (!projectName) {
   throw Error("No 'projectName' provided");
 }
 
-const azureDatabaseHost = $.env.AZURE_DATABASE_HOST;
-
 const sourceNamespace = projectName + "-main";
 const sourceDatabaseConnectionInfo = await getDatabaseConnectionInfo(sourceNamespace);
 await makeDatabaseDump(sourceDatabaseConnectionInfo, projectName);
@@ -58,12 +56,13 @@ async function getDatabaseConnectionInfo(namespace) {
 
   const databaseConnectionInfo = {
     databaseName: data.MARIADB_DATABASE,
-    databaseHost: azureDatabaseHost,
+    databaseHost: data.MARIADB_HOST,
     databaseUser:  data.MARIADB_USERNAME,
     databasePassword: data.MARIADB_PASSWORD,
   };
 
   if(data.MARIADB_DATABASE_OVERRIDE) {
+    echo('using OVERRIDE variables');
     databaseConnectionInfo.databaseName = data.MARIADB_DATABASE_OVERRIDE;
     databaseConnectionInfo.databaseHost = data.MARIADB_HOST_OVERRIDE;
     databaseConnectionInfo.databasePassword = data.MARIADB_PASSWORD_OVERRIDE;

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -104,7 +104,7 @@ async function importMainDumpIntoModuletestDatabase(databaseConnectionInfo, proj
   } = databaseConnectionInfo;
 
   try {
-    await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush drop && mariadb --user=${databaseUser} --host=${databaseHost} --password=${databasePassword} ${databaseName} < /tmp/${projectName}-dump.sql"`
+    await $`kubectl exec -n ${projectName}-moduletest deployment/cli -- bash -c "drush sql-drop && mariadb --user=${databaseUser} --host=${databaseHost} --password=${databasePassword} ${databaseName} < /tmp/${projectName}-dump.sql"`
   } catch(error) {
     echo(`Failed to import dump into ${projectName}-moduletest's database`, error.stderr);
     throw Error(`Failed to import dump into ${projectName}-moduletest's database`, { cause: error });

--- a/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
+++ b/infrastructure/images/moduletest-reset-job/moduletest-reset-job.mjs
@@ -56,7 +56,7 @@ async function getDatabaseConnectionInfo(namespace) {
 
   const databaseConnectionInfo = {
     databaseName: data.MARIADB_DATABASE,
-    databaseHost: data.MARIADB_HOST,
+    databaseHost: await $`kubectl get svc -n ${namespace} ${data.MARIADB_HOST} -o --jsonpath={.spec.externalName}`,
     databaseUser:  data.MARIADB_USERNAME,
     databasePassword: data.MARIADB_PASSWORD,
   };


### PR DESCRIPTION
This PR does a couple of things
- It drops the tables of the database before importing the new one from main
- Now tells us if it is using the override variables 
- Gets the database host from the service