### PR TITLE
remove cert-manager-verifier

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -287,14 +287,6 @@ tasks:
       cmds:
         - task/scripts/provision-cert-manager.sh
 
-    support:verify:cert-manager:
-      deps: [cluster:auth]
-      summary: Verify cert-manager
-      desc: Attempts to verify that cert-manager is installed and configured correctly.
-      cmds:
-        - cm-verifier
-        - kubectl get pods --namespace cert-manager
-
     support:provision:minio:
       deps: [cluster:auth]
       summary: Set the DIFF environment variable to any value to switch to diffing instead of an actual upgrade.

--- a/tools/dplsh/Dockerfile
+++ b/tools/dplsh/Dockerfile
@@ -16,9 +16,6 @@ FROM mcr.microsoft.com/azure-cli:2.63.0
 ARG TASK_VERSION=v3.40.0
 # See https://github.com/uselagoon/lagoon-cli/releases
 ARG LAGOON_CLI_RELEASE=v0.31.1
-# https://github.com/alenkacz/cert-manager-verifier/releases
-# Exclude the "v" from the version.
-ARG CERT_MANAGER_VERIFIER_VERSION=0.3.0
 
 # The kubectl version can be bumped as we upgrade the cluster minor version.
 ARG KUBECTL_VERSION=v1.29.5
@@ -64,17 +61,6 @@ COPY --from=terraform /bin/terraform /bin/
 
 # Add Helm
 COPY --from=helm /usr/bin/helm /usr/bin/
-
-# Add cert-manager verifyer
-RUN ( \
-    set -x; cd "$(mktemp -d)" && \
-    OS="$(uname)" && \
-    ARCH="$(uname -m | sed -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" && \
-    ARTIFACT_NAME="cert-manager-verifier_${CERT_MANAGER_VERIFIER_VERSION}_${OS}_${ARCH}.tar.gz" && \
-    curl -fsSLO "https://github.com/alenkacz/cert-manager-verifier/releases/download/v${CERT_MANAGER_VERIFIER_VERSION}/${ARTIFACT_NAME}" && \
-    tar zxvf "${ARTIFACT_NAME}" && \
-    mv ./cm-verifier /usr/bin/ \
-  )
 
 # Create a dplsh user and switch to it to avoid running the shell as root
 RUN adduser -D --shell /bin/bash dplsh


### PR DESCRIPTION
I suggest to remove cert-manager-verifier from DPLSH because we're not using it. Removing it will also make it easier to get out DPLSH down the road - and for good measure: less code is better