### PR TITLE
Scale up PHP pod, when it starts using more than just above 50% of CP…

### DIFF
--- a/gitops/charts/autoscalers/templates/nginx-hpa.yaml
+++ b/gitops/charts/autoscalers/templates/nginx-hpa.yaml
@@ -4,14 +4,15 @@ metadata:
   name: nginx-hpa
 spec:
   minReplicas: 1
-  maxReplicas: 1
+  maxReplicas: 6
   metrics:
-    - type: Resource
-      resource:
+    - type: ContainerResource
+      containerResource:
         name: cpu
+        container: php
         target:
           type: Utilization
-          averageUtilization: 80
+          averageUtilization: 65
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/gitops/dplplat01/sites/bronderslev-main/templates/database-user.yaml
+++ b/gitops/dplplat01/sites/bronderslev-main/templates/database-user.yaml
@@ -11,4 +11,4 @@ spec:
   passwordSecretKeyRef:
     name: database-secret
     key: password
-  maxUserConnections: 50
+  maxUserConnections: 100


### PR DESCRIPTION
My suggestion to fixing the issues we are seeing with bad service on some of the sites (in this case, namely Bronderslev), is to scale a little early on 65% of requested CPU usage. This should probably be tweaked as we go, but the reasoning is this: let sites that might potentially start seeing a lot of visitors, spin up more pods preemptively. This will also allow us to make use of more database connections, as PHP-FPM can use more than 50. My second suggestion is therefore, due to a conversation with Fini and Kasper, to allow for more database connections per user. 
For starters, I think we should test it out on Bronderslev and monitor how it plays out, and then make some adjustments 

