### PR TITLE
Update Lagoon images to 26.3.0

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ENVIRONMENT_REPO_ORG=danishpubliclibraries
-LAGOON_IMAGES_RELEASE_TAG="24.1.0"
+LAGOON_IMAGES_RELEASE_TAG="26.3.0"
 
 # Echo the second argument Exit 1 if the first argument is not 0
 # Use this function to process $? after an invocation of something that might

--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/node.dockerfile
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/node.dockerfile
@@ -15,10 +15,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN yarn run build
 
 # Production image, copy all the files and run next
-# TODO: Replace the fixed version, 26.3.0, with ${LAGOON_IMAGES_RELEASE_TAG}
-# when ${LAGOON_IMAGES_RELEASE_TAG} has caught up so all images are updated in
-# lockstep.
-FROM uselagoon/node-${NODE_VERSION}:26.3.0 AS runner
+FROM uselagoon/node-${NODE_VERSION}:${LAGOON_IMAGES_RELEASE_TAG} AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
#### What does this PR do?

This ensures that we are working with the latest version e.g. https://hub.docker.com/r/uselagoon/node-24/tags.

Also align the node.dockerfile with the other dockerfiles by using the shared LAGOON_IMAGES_RELEASE_TAG variable instead of a hardcoded version.

This is a continuation of discussions in #1084.

#### Should this be tested by the reviewer and how?

This can only be done by deploying this to the canary site.

#### Any specific requests for how the PR should be reviewed?

Not really.

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDF-179