### PR TITLE
clean up old lagoon routes

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -344,6 +344,18 @@ tasks:
       - sh: '[ ! -z "{{.PROJECT_NAME}}" ]'
         msg: "Missing PROJECT_NAME"
 
+  lagoon:project:ensure:lagoon-routes-clean-up:
+    cmds:
+      - task: lagoon:ensure:environment-variable
+        vars:
+          VARIABLE_SCOPE: "GLOBAL"
+          VARIABLE_NAME: "LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES"
+          VARIABLE_VALUE: "enabled"
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+    preconditions:
+      - sh: '[ ! -z "{{.PROJECT_NAME}}" ]'
+        msg: "Missing PROJECT_NAME"
+
   #These are secrets which are identical across prjects, so ie. Copenhagen has the same value as Ballerup
   lagoon:projects:env-variables:ensure:identical-across-projects:
     cmds:
@@ -380,6 +392,9 @@ tasks:
         vars:
           PROJECT_NAME: "{{.PROJECT_NAME}}"
       - task: lagoon:project:ensure:azure-mail-connection-string
+        vars:
+          PROJECT_NAME: "{{.PROJECT_NAME}}"
+      - task: lagoon:project:ensure:lagoon-routes-clean-up
         vars:
           PROJECT_NAME: "{{.PROJECT_NAME}}"
     preconditions:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This will clean up the old Lagoon routes that have not been used since the move from Azure to Computerome

#### Should this be tested by the reviewer and how?
This has been tested on Customizable and canary

#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
