### PR TITLE
Deploy 2026.18.1 to editors and moduletests

### DIFF
--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,32 +2,20 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  # IMPORTANT! When updating to 2026.18.x, the node-version below needs to be updated to 24.
-  # See https://github.com/danskernesdigitalebibliotek/dpl-platform/pull/1085
-  dpl-cms-release: 2026.16.0
-  go-release: 2026.16.0
+  dpl-cms-release: 2026.18.1
+  go-release: 2026.18.1
   php-version: 8.3
-  node-version: 20
+  node-version: 24
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   # This release cycle releases the newest release, which has been
   # tested on webmaster moduletests in the previous week, on to
   # production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: 2026.13.0
-  moduletest-dpl-cms-release: 2026.16.0
-  go-release: 2026.13.0
-  php-version: 8.3
-  node-version: 20
-x-webmasters-on-early-update: &webmasters-on-early-update
-  # 2026.13.0 contained an issue that most of the webmasters can't
-  # live with, so we're updating them early. They should be put back
-  # on the normal release cycle when that is upgraded to 2026.16.0 on
-  # main.
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
+  # IMPORTANT! When updating to 2026.18.x, the node-version below needs to be updated to 24.
+  # See https://github.com/danskernesdigitalebibliotek/dpl-platform/pull/1085
   dpl-cms-release: 2026.16.0
-  moduletest-dpl-cms-release: 2026.16.0
+  moduletest-dpl-cms-release: 2026.18.1
   go-release: 2026.16.0
   php-version: 8.3
   node-version: 20
@@ -41,11 +29,11 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: 2026.16.0
-    moduletest-dpl-cms-release: 2026.16.0
-    go-release: 2026.16.0
+    dpl-cms-release: 2026.18.1
+    moduletest-dpl-cms-release: 2026.18.1
+    go-release: 2026.18.1
     php-version: 8.3
-    node-version: 20
+    node-version: 24
     diskSize: 20
     primary-domain: canary.dplplat02.dpl.reload.dk
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
@@ -59,11 +47,11 @@ sites:
     releaseImageName: dpl-cms-source
     primary-domain: customizable.dplplat02.dpl.reload.dk
     plan: webmaster
-    dpl-cms-release: 2026.16.0
-    moduletest-dpl-cms-release: 2026.16.0
-    go-release: 2026.16.0
+    dpl-cms-release: 2026.18.1
+    moduletest-dpl-cms-release: 2026.18.1
+    go-release: 2026.18.1
     php-version: 8.3
-    node-version: 20
+    node-version: 24
     diskSize: 20
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILj8lXv7C/7s7te9sEpwcHQhgDWfzsCkAN7rqQ4sdTzk"
   staging:
@@ -94,7 +82,7 @@ sites:
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
     # has been updated to use the primary domain.
     autogenerateRoutes: true
-    moduletest-dpl-cms-release: 2026.16.0
+    moduletest-dpl-cms-release: 2026.18.1
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we
     # follow the default release plan and update the module test site manually.
@@ -105,7 +93,7 @@ sites:
     description: "Et site hvor bibliotekerne kan teste"
     primary-domain: bibliotek-test.dplplat02.dpl.reload.dk
     plan: webmaster
-    go-release: 2026.16.0
+    go-release: 2026.18.1
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
     diskSize: 5
     <<: *webmasters-on-weekly-release-cycle
@@ -152,7 +140,7 @@ sites:
     autogenerateRoutes: "redirect"
     plan: webmaster
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
@@ -163,7 +151,7 @@ sites:
       - aakb.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   aero:
     name: "Ærø Folkebibliotek"
     description: "The library site for Ærø"
@@ -184,7 +172,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   allerod:
     name: "Allerød Biblioteker"
     description: "The library site for Allerød"
@@ -215,7 +203,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   billund:
     name: "Billund Bibliotekerne og Borgerservice"
     description: "The main library site for Billund"
@@ -499,7 +487,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
     diskSize: 20
   hillerod:
     name: "Hillerød Bibliotekerne"
@@ -797,7 +785,7 @@ sites:
       - odensebib.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   odsherred:
     name: "Odsherred Bibliotek og Kulturhuse"
     description: "The library site for Odsherred"
@@ -870,7 +858,7 @@ sites:
       - roskildebib.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   rudersdal:
     name: "Rudersdal Bibliotekerne"
     description: "The library site for Rudersdal"
@@ -901,7 +889,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"
@@ -943,7 +931,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   soro:
     name: "Sorø Bibliotek"
     description: "The library site for Sorø"
@@ -1015,7 +1003,7 @@ sites:
       - www.taarnbybib.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *webmasters-on-early-update
+    <<: *webmasters-on-weekly-release-cycle
   thisted:
     name: "Biblioteket i Thy"
     description: "The library site for Thisted"


### PR DESCRIPTION
Revert the webmaster early adopters of 2026.16.0 to following the normal release cycle.
