### PR TITLE
allow bigger headers for all ingress' in the cluster by default

### DIFF
--- a/gitops/dplplat02/ingress-nginx/values.yaml
+++ b/gitops/dplplat02/ingress-nginx/values.yaml
@@ -60,6 +60,7 @@ ingress-nginx:
       # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
       # and https://github.com/uselagoon/lagoon-images/blob/main/images/nginx/nginx.conf#L81
       proxy-body-size: "2048m"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     # -- Annotations to be added to the controller config configuration configmap.
     configAnnotations: {}
     # -- Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
The purpose of this is to solve the issue that we can't allow greater headers on pr-envs as Lagoon does not expose dynamics routes 

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
