### PR TITLE
revert cron jobs back to the original setting

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -65,7 +65,7 @@ $SECONDARY_DOMAINS
 $PRIMARY_GO_SUBDOMAIN_AND_ANNOTATION
 $SECONDARY_GO_SUBDOMAINS
     cronjobs:
-      - name: run drush cron
+      - name: drush cron
         schedule: "M/15 * * * *"
         command: drush cron
         service: cli

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -70,15 +70,15 @@ $SECONDARY_GO_SUBDOMAINS
         command: drush cron
         service: cli
       - name: import translations
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush locale-check && drush locale-update
         service: cli
       - name: import danish config translations
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-web/cms/translations/da.config.po
         service: cli
       - name: drush err:purge
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush err:purge paragraph
         service: cli
   moduletest:
@@ -88,15 +88,15 @@ $SECONDARY_GO_SUBDOMAINS
         command: drush cron
         service: cli
       - name: import translations
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush locale-check && drush locale-update
         service: cli
       - name: import danish config translations
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-web/cms/translations/da.config.po
         service: cli
       - name: drush err:purge
-        schedule: "M * * * *"
+        schedule: "M H(00-04) * * *"
         command: drush err:purge paragraph
         service: cli
 

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -65,38 +65,38 @@ $SECONDARY_DOMAINS
 $PRIMARY_GO_SUBDOMAIN_AND_ANNOTATION
 $SECONDARY_GO_SUBDOMAINS
     cronjobs:
-      - name: drush cron
-        schedule: "M/15 6-23 * * *"
+      - name: run drush cron
+        schedule: "M/15 * * * *"
         command: drush cron
         service: cli
       - name: import translations
-        schedule: "M H(23-2) * * *"
+        schedule: "M * * * *"
         command: drush locale-check && drush locale-update
         service: cli
       - name: import danish config translations
-        schedule: "M H(2-5) * * *"
+        schedule: "M * * * *"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-web/cms/translations/da.config.po
         service: cli
       - name: drush err:purge
-        schedule: "M 6-22 * * *"
+        schedule: "M * * * *"
         command: drush err:purge paragraph
         service: cli
   moduletest:
     cronjobs:
       - name: drush cron
-        schedule: "M/15 6-23 * * *"
+        schedule: "M/15 * * * *"
         command: drush cron
         service: cli
       - name: import translations
-        schedule: "M H(23-2) * * *"
+        schedule: "M * * * *"
         command: drush locale-check && drush locale-update
         service: cli
       - name: import danish config translations
-        schedule: "M H(2-5) * * *"
+        schedule: "M * * * *"
         command: drush dpl_po:import-remote-config-po da https://danskernesdigitalebibliotek.github.io/dpl-web/cms/translations/da.config.po
         service: cli
       - name: drush err:purge
-        schedule: "M 6-22 * * *"
+        schedule: "M * * * *"
         command: drush err:purge paragraph
         service: cli
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?
This should revert the scheduling of the cronjobs back to their original setting

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
