### PR TITLE
Use named capture groups for legacy rewrites

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
+++ b/infrastructure/dpladm/env-repo-template/standard/lagoon/conf/nginx/server_append_drupal_rewrite_legacy_search_works.conf
@@ -14,7 +14,7 @@
 # - /search/ting/harry%20potter?page=1
 # New path:
 # - /search?q=harry%2520potter
-rewrite ^/search/ting/([^/?]+) /search?q=$1? permanent;
+rewrite ^/search/ting/(?<q>[^/?]+) /search?q=$q? permanent;
 
 # Redirect materials.
 # The legacy system had separate paths for works (collections) and
@@ -28,4 +28,4 @@ rewrite ^/search/ting/([^/?]+) /search?q=$1? permanent;
 # - /ting/object/870970-basis%3A47086868
 # New path:
 # - /work/work-of:870970-basis%3A47086868
-rewrite ^/ting/(object|collection)/([^/?]+) /work/work-of:$2? permanent;
+rewrite ^/ting/(?:object|collection)/(?<id>[^/?]+) /work/work-of:$id? permanent;


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Use named capture groups for legacy rewrites

This replicates https://github.com/danskernesdigitalebibliotek/dpl-web/pull/761

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDF-294