### PR TITLE
Update Lagoon images to release 2026.5.1

### DIFF
--- a/infrastructure/dpladm/bin/dpladm-shared.source
+++ b/infrastructure/dpladm/bin/dpladm-shared.source
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ENVIRONMENT_REPO_ORG=danishpubliclibraries
-LAGOON_IMAGES_RELEASE_TAG="26.3.0"
+LAGOON_IMAGES_RELEASE_TAG="26.5.1"
 
 # Echo the second argument Exit 1 if the first argument is not 0
 # Use this function to process $? after an invocation of something that might


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

This includes updated versions of our dependencies as well as a range of security updates.

See:

- https://github.com/uselagoon/lagoon-images/releases/tag/26.4.0
- https://github.com/uselagoon/lagoon-images/releases/tag/26.5.0
- https://github.com/uselagoon/lagoon-images/releases/tag/26.5.1