### PR TITLE
Fix references to old repos and old Lagoon

### DIFF
--- a/docs/architecture/adr/adr-004-declarative-site-management.md
+++ b/docs/architecture/adr/adr-004-declarative-site-management.md
@@ -51,7 +51,7 @@ automated deployment process which renderers the various files contained in the
 repository including a reference to which release of DPL-CMS Lagoon should use.
 
 It is still possible to create and maintain sites on Lagoon independent of this
-approach. We can for instance create a separate project for the [dpl-cms](https://github.com/danskernesdigitalebibliotek/dpl-cms)
+approach. We can for instance create a separate project for the [dpl-web](https://github.com/danskernesdigitalebibliotek/dpl-web)
 repository to support core development.
 
 ## Status

--- a/docs/architecture/adr/adr-005-declarative-site-management-2.md
+++ b/docs/architecture/adr/adr-005-declarative-site-management-2.md
@@ -39,7 +39,7 @@ This leads to at least two concrete steps:
   into the `main` branch. This means state divergence between the platform repo
   declaration and reality is minimized.
 
-It will *still* be possible for `dpl-cms` to maintain its own area of state
+It will *still* be possible for `dpl-web` to maintain its own area of state
 in the platform, but anything declared in `dpl-platform` will be much more
 likely to be the actual state in the platform.
 

--- a/docs/architecture/performance-strategy.md
+++ b/docs/architecture/performance-strategy.md
@@ -35,7 +35,7 @@ docs.lagoon.sh documentation on [the Varnish service](https://docs.lagoon.sh/lag
 and the [varnish-drupal image](https://docs.lagoon.sh/lagoon/docker-images/varnish/varnish-drupal)
 for the specifics on the service.
 
-Refer to the caching documentation in [dpl-cms](https://github.com/danskernesdigitalebibliotek/dpl-cms)
+Refer to the caching documentation in [dpl-web](https://github.com/danskernesdigitalebibliotek/dpl-web)
 for specifics on how DPL-CMS is integrated with Varnish.
 
 ## Redis as caching backend

--- a/docs/lagoon-projects.md
+++ b/docs/lagoon-projects.md
@@ -1,6 +1,6 @@
 # Lagoon projects
 
-The Lagoon instance at `dplplat01.dpl.reload.dk` contains a range of
+The Lagoon instance at `dplplat02.dpl.reload.dk` contains a range of
 sites of a slightly different nature.
 
 ## Development sites

--- a/docs/platform-environments.md
+++ b/docs/platform-environments.md
@@ -9,9 +9,9 @@
 
 ### URLs
 
-* Base domain: `dplplat01.dpl.reload.dk`
-* Grafana: <https://grafana.lagoon.dplplat01.dpl.reload.dk/>
-* Lagoon UI: <https://ui.lagoon.dplplat01.dpl.reload.dk/>
+* Base domain: `dplplat02.dpl.reload.dk`
+* Grafana: <https://grafana.lagoon.dplplat02.dpl.reload.dk/>
+* Lagoon UI: <https://ui.lagoon.dplplat02.dpl.reload.dk/>
 
 ### DNS setup for library sites
 
@@ -22,10 +22,10 @@ CNAME: cluster-1.folkebibliotekernescms.dk
 
 ### Lagoon CLI configuration
 
-* Lagoon name: dplplat01
-* Lagoon UI: <https://ui.lagoon.dplplat01.dpl.reload.dk/>
-* GraphQL endpoint: <https://api.lagoon.dplplat01.dpl.reload.dk/graphql>
-* SSH host: 20.238.147.183
+* Lagoon name: dplplat02
+* Lagoon UI: <https://ui.lagoon.dplplat02.dpl.reload.dk/>
+* GraphQL endpoint: <https://api.lagoon.dplplat02.dpl.reload.dk/graphql>
+* SSH host: 130.226.25.97
 * SSH port: 22
 
 ## Obtaining Lagoon CLI configuration

--- a/docs/runbooks/add-generic-site-to-platform.md
+++ b/docs/runbooks/add-generic-site-to-platform.md
@@ -6,7 +6,7 @@ When you want to add a "generic" site to the platform. By Generic we mean a site
 stored in a repository that that is [Prepared for Lagoon](https://docs.lagoon.sh/drupal/step-by-step-getting-drupal-ready-to-run-on-lagoon/)
 and contains a `.lagoon.yml` at its root.
 
-The current main example of such as site is [dpl-cms](https://github.com/danskernesdigitalebibliotek/dpl-cms)
+The current main example of such as site is [dpl-web](https://github.com/danskernesdigitalebibliotek/dpl-web)
 which is used to develop the shared DPL install profile.
 
 ## Prerequisites
@@ -43,7 +43,7 @@ $ eval $(ssh-agent); ssh-add
 
 # 1. Add a project
 # PROJECT_NAME=<project name>  GIT_URL=<url> task lagoon:project:add
-$ PROJECT_NAME=dpl-cms GIT_URL=git@github.com:danskernesdigitalebibliotek/dpl-cms.git\
+$ PROJECT_NAME=dpl-web GIT_URL=git@github.com:danskernesdigitalebibliotek/dpl-web.git\
   task lagoon:project:add
 
 # 1.b You can also run lagoon add project manually, consult the documentation linked
@@ -52,7 +52,7 @@ $ PROJECT_NAME=dpl-cms GIT_URL=git@github.com:danskernesdigitalebibliotek/dpl-cm
 # 2. Deployment key
 # The project is added, and a deployment key is printed. Copy it and configure
 # the GitHub repository. See the official documentation for examples.
-$ PROJECT_NAME=dpl-cms task lagoon:project:deploykey
+$ PROJECT_NAME=dpl-web task lagoon:project:deploykey
 
 # 3. Webhook
 # Configure Github to post events to Lagoons webhook url.
@@ -67,5 +67,5 @@ $ PROJECT_NAME=dpl-cms task lagoon:project:deploykey
 # 4. Trigger a deployment manually, this will fail as the repository is empty
 #    but will serve to prepare Lagoon for future deployments.
 # lagoon deploy branch -p <project-name> -b <branch>
-$ lagoon deploy branch -p dpl-cms -b main
+$ lagoon deploy branch -p dpl-web -b main
 ```

--- a/docs/runbooks/add-generic-site-to-platform.md
+++ b/docs/runbooks/add-generic-site-to-platform.md
@@ -58,8 +58,8 @@ $ PROJECT_NAME=dpl-web task lagoon:project:deploykey
 # Configure Github to post events to Lagoons webhook url.
 # The webhook url for the environment will be
 #  https://webhookhandler.lagoon.<environment>.dpl.reload.dk
-# eg for the environment dplplat01
-#  https://webhookhandler.lagoon.dplplat01.dpl.reload.dk
+# eg for the environment dplplat02
+#  https://webhookhandler.lagoon.dplplat02.dpl.reload.dk
 #
 # Referer to the official documentation linked above for an example on how to
 # set up webhooks in github.

--- a/docs/runbooks/connecting-the-lagoon-cli.md
+++ b/docs/runbooks/connecting-the-lagoon-cli.md
@@ -75,12 +75,12 @@ $ lagoon config add \
 
 # Eg.
 $ lagoon config add \
-    --graphql https://api.lagoon.dplplat01.dpl.reload.dk/graphql \
+    --graphql https://api.lagoon.dplplat02.dpl.reload.dk/graphql \
     --force \
-    --ui https://ui.lagoon.dplplat01.dpl.reload.dk \
-    --hostname 20.238.147.183 \
+    --ui https://ui.lagoon.dplplat02.dpl.reload.dk \
+    --hostname 130.226.25.97 \
     --port 22 \
-    --lagoon dplplat01
+    --lagoon dplplat02
 ```
 
 Then log in:
@@ -92,7 +92,7 @@ lagoon login
 lagoon whoami
 
 # Eg.
-lagoon config default --lagoon dplplat01
+lagoon config default --lagoon dplplat02
 lagoon login
 lagoon whoami
 ```

--- a/docs/runbooks/troubleshoot-lagoon-cli-connection.md
+++ b/docs/runbooks/troubleshoot-lagoon-cli-connection.md
@@ -63,7 +63,7 @@ Now delete the bad entry by by running this command:
 If you have the Lagoon CLI installed on your local machine you can run this part
 while outside of the shell. Otherwise, open the shell, but don't log in yet.
 Now readd the Lagoon Config, but add a pointer to which ssh key to use:
-`lagoon config add --lagoon dplplat01
+`lagoon config add --lagoon dplplat02
 lagoon config add \
     --graphql https://api.lagoon.dplplat02.dpl.reload.dk/graphql \
     --force \

--- a/docs/runbooks/ui-sync-site-state.md
+++ b/docs/runbooks/ui-sync-site-state.md
@@ -13,7 +13,7 @@ moduletest environment, if requested by the customer.
 ## Prerequisites
 
 - A user with access to the relevant project through the
-  [Lagoon UI](https://ui.lagoon.dplplat01.dpl.reload.dk/)
+  [Lagoon UI](https://ui.lagoon.dplplat02.dpl.reload.dk/)
 
 If you have access to the dpl-platform setup and can run task in the taskfile
 (for platform engineers, not developers of the CMS) you may want to synchronize

--- a/docs/runbooks/upgrading-support-workloads.md
+++ b/docs/runbooks/upgrading-support-workloads.md
@@ -240,7 +240,7 @@ kubectl -n harbor get pods
 ```
 
 When Harbor seems to be working, you can verify that the UI is working by
-accessing <https://harbor.lagoon.dplplat01.dpl.reload.dk/>. The password for
+accessing <https://harbor.lagoon.dplplat02.dpl.reload.dk/>. The password for
 the user `admin` can be retrived with the following command:
 
 ```bash
@@ -311,7 +311,7 @@ kubectl -n ingress-nginx get pods
 Then verify that the ingress-controller is able to serve traffic. This can be
 done by accessing the UI of one of the apps that are deployed in the platform.
 
-Access eg. <https://ui.lagoon.dplplat01.dpl.reload.dk/>.
+Access eg. <https://ui.lagoon.dplplat02.dpl.reload.dk/>.
 
 ### K8up
 

--- a/gitops/charts/proxy-pass-service/templates/varnish-deployment.yaml
+++ b/gitops/charts/proxy-pass-service/templates/varnish-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: lagoon-env
-        image: harbor.lagoon.dplplat01.dpl.reload.dk/{{ trimSuffix "-main" .Release.Namespace }}/main/varnish
+        image: harbor.lagoon.dplplat02.dpl.reload.dk/{{ trimSuffix "-main" .Release.Namespace }}/main/varnish
         name: proxy-pass-varnish
         ports:
         - containerPort: 8080

--- a/gitops/dplplat02/argo-cd-resources/values.yaml
+++ b/gitops/dplplat02/argo-cd-resources/values.yaml
@@ -349,7 +349,7 @@ sites:
   - name: cms-school-main
     automated: false
     proxy-pass-service:
-      host: cms-school.dplplat01.dpl.reload.dk
+      host: cms-school.dplplat02.dpl.reload.dk
       target: internal
 
   - name: cms-school-moduletest

--- a/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/.lagoon.yml
@@ -2,8 +2,8 @@ docker-compose-yaml: docker-compose.yml
 
 project: ${LAGOON_PROJECT_NAME}
 
-ssh: 20.238.147.183:22
-api: https://api.lagoon.dplplat01.dpl.reload.dk/graphql
+ssh: 130.226.25.97:22
+api: https://api.lagoon.dplplat02.dpl.reload.dk/graphql
 
 tasks:
   post-rollout:

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -2,6 +2,6 @@
 
 This is an overview of our environments.
 
-## dplplat01
+## dplplat02
 
 Initial environment used during the first implementation of the platform.

--- a/infrastructure/environments/dplplat01/infrastructure/main.tf
+++ b/infrastructure/environments/dplplat01/infrastructure/main.tf
@@ -5,7 +5,7 @@ module "environment" {
   environment_name = "dplplat01"
   # This variable current _has_ to match the pattern
   # <environment_name>.dpl.reload.dk
-  lagoon_domain_base = "dplplat01.dpl.reload.dk"
+  lagoon_domain_base = "dplplat02.dpl.reload.dk"
   random_seed        = "LahYegheePhohGeew9Fa"
   node_pools = {
     "app4" : { min : 11, max : 20, vm : "Standard_E4s_v3", max_pods : 70 },

--- a/infrastructure/environments/dplplat01/sites.example.yaml
+++ b/infrastructure/environments/dplplat01/sites.example.yaml
@@ -1,8 +1,7 @@
 # Configure the source we default to when looking for release images.
-x-defaults:
-  &default-release-image-source
-    releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-    releaseImageName: dpl-cms-source
+x-defaults: &default-release-image-source
+  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
+  releaseImageName: dpl-cms-source
 
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
@@ -10,45 +9,45 @@ sites:
   tbd-core-test01:
     name: "Core test 01"
     description: "Core test site no. 01"
-    << : *default-release-image-source
+    <<: *default-release-image-source
     dpl-cms-release: "0.6.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWJ++ijZpWsZdHvKuWEwOvyshQ5EOEOP3SXv7eC9MPr"
   tbd-core-test02:
     name: "Core test 02"
     description: "Core test site no. 02"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test03:
     name: "Core test 03"
     description: "Core test site no. 03"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test04:
     name: "Core test 04"
     description: "Core test site no. 04"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test05:
     name: "Core test 05"
     description: "Core test site no. 05"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test06:
     name: "Core test 06"
     description: "Core test site no. 06"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test07:
     name: "Core test 07"
     description: "Core test site no. 07"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test08:
     name: "Core test 08"
     description: "Core test site no. 08"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test09:
     name: "Core test 09"
     description: "Core test site no. 09"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-core-test10:
     name: "Core test 10"
     description: "Core test site no. 10"
-    << : *default-release-image-source
+    <<: *default-release-image-source
   tbd-programmer-demo:
     name: "Programmer Profile Demo"
     description: "Test that we can deploy custom images to a site"
@@ -59,8 +58,9 @@ sites:
   tbd-bib-rb:
     name: "Rødovre Bibliotek"
     description: "PoC environment for Rødovre Bibliotek"
-    primary-domain: "rdb.dplplat01.dpl.reload.dk"
-    secondary-domains: ["www.rdb.dplplat01.dpl.reload.dk", "www2.rdb.dplplat01.dpl.reload.dk"]
+    primary-domain: "rdb.dplplat02.dpl.reload.dk"
+    secondary-domains:
+      ["www.rdb.dplplat02.dpl.reload.dk", "www2.rdb.dplplat02.dpl.reload.dk"]
     dpl-cms-release: "0.6.0"
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEEqMszAfB6roiO49D1Zu407G2cUvCAhiJkI3sPOzQCs"
-    << : *default-release-image-source
+    <<: *default-release-image-source

--- a/infrastructure/images/lagoon-redeploy-controller/redeploy-controller.mjs
+++ b/infrastructure/images/lagoon-redeploy-controller/redeploy-controller.mjs
@@ -6,22 +6,21 @@ const time = function() {
 }
 
 console.log("### Starting controller");
-console.log("adding dplplat01 lagoon config");
+console.log("adding dplplat02 lagoon config");
 await $`lagoon config add \
-  --graphql https://api.lagoon.dplplat01.dpl.reload.dk/graphql \
+  --graphql https://api.lagoon.dplplat02.dpl.reload.dk/graphql \
   --force \
-  --ui https://ui.lagoon.dplplat01.dpl.reload.dk \
-  --hostname 20.238.147.183 \
+  --ui https://ui.lagoon.dplplat02.dpl.reload.dk \
+  --hostname 130.226.25.97 \
   --port 22 \
-  --lagoon dplplat01 \
+  --lagoon dplplat02 \
   --ssh-key /root/.ssh/id_rsa`;
 
 await $`lagoon config feature --strict-host-key-checking "no"`;
 
-await $`lagoon config default --lagoon dplplat01`;
+await $`lagoon config default --lagoon dplplat02`;
 
-
-// verify that dplplat01 is the active lagoon
+// verify that dplplat02 is the active lagoon
 console.log("### Show current Lagoon");
 echo(await $`lagoon config list`);
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
<!-- markdownlint-disable no-multiple-blanks -->
#### What does this PR do?

Documentation now points to the new monorepo and the new Lagoon setup.

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDF-281