### PR TITLE
Roll out new moduletest reseter

### DIFF
--- a/gitops/charts/moduletest-reset-cronjob/Chart.yaml
+++ b/gitops/charts/moduletest-reset-cronjob/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: moduletest-reset
-version: 0.0.20
+version: 0.0.21

--- a/gitops/charts/moduletest-reset-cronjob/templates/moduletest-reset-cronjob.yaml
+++ b/gitops/charts/moduletest-reset-cronjob/templates/moduletest-reset-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: moduletest-reset-container
-              image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset:mr-2.1.0
+              image: ghcr.io/danskernesdigitalebibliotek/dpl-platform/moduletest-reset:mr-2.1.1
               command:
                 - /bin/bash
                 - -c


### PR DESCRIPTION
#### What does this PR do?
This creates a new chart for the moduletest-reset job. It will have to be fixed again post the next roll out

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
https://reload.atlassian.net/jira/software/c/projects/DDFDRIFT/boards/802?selectedIssue=DDFDRIFT-625