### PR TITLE
Upgrade from Redis v6 to Valkey v8

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.base-services.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.base-services.yml
@@ -70,9 +70,9 @@ services:
       <<: *default-environment
 
   redis:
-    image: uselagoon/redis-6:latest
+    image: uselagoon/valkey-8:latest
     labels:
-      lagoon.type: redis
+      lagoon.type: valkey
     <<: *default-user # uses the defined user from top
     environment:
       <<: *default-environment

--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.node-service.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.node-service.yml
@@ -70,9 +70,9 @@ services:
       <<: *default-environment
 
   redis:
-    image: uselagoon/redis-6:latest
+    image: uselagoon/valkey-8:latest
     labels:
-      lagoon.type: redis
+      lagoon.type: valkey
     <<: *default-user # uses the defined user from top
     environment:
       <<: *default-environment


### PR DESCRIPTION
#### What does this PR do?

Lagoon currently recommends Valkey over Redis, and for our use case, they are functionally identical.


#### What are the relevant tickets?

[DDF-298](https://reload.atlassian.net/browse/DDF-298)


[DDF-298]: https://reload.atlassian.net/browse/DDF-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ