### PR TITLE
Use Redis 8 instead of Valkey 8

### DIFF
--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.base-services.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.base-services.yml
@@ -70,9 +70,9 @@ services:
       <<: *default-environment
 
   redis:
-    image: uselagoon/valkey-8:latest
+    image: uselagoon/redis-8:latest
     labels:
-      lagoon.type: valkey
+      lagoon.type: redis
     <<: *default-user # uses the defined user from top
     environment:
       <<: *default-environment

--- a/infrastructure/dpladm/env-repo-template/standard/docker-compose.node-service.yml
+++ b/infrastructure/dpladm/env-repo-template/standard/docker-compose.node-service.yml
@@ -70,9 +70,9 @@ services:
       <<: *default-environment
 
   redis:
-    image: uselagoon/valkey-8:latest
+    image: uselagoon/redis-8:latest
     labels:
-      lagoon.type: valkey
+      lagoon.type: redis
     <<: *default-user # uses the defined user from top
     environment:
       <<: *default-environment


### PR DESCRIPTION
#### What does this PR do?

Switch to Redis 8 instead of Valkey 8 reflecting
https://github.com/danskernesdigitalebibliotek/dpl-web/pull/1263

#### What are the relevant tickets?

https://reload.atlassian.net/browse/DDF-291