### PR TITLE
release/2026.32.x

### DIFF
--- a/infrastructure/Taskfile.yml
+++ b/infrastructure/Taskfile.yml
@@ -446,6 +446,10 @@ tasks:
       SITES_CONFIG: "{{.dir_env}}/sites.yaml"
       SITE: "{{.SITE}}"
       GITHUB_TOKEN: "{{.GITHUB_TOKEN}}"
+      # Optional release filter. When set (eg. ONLY_RELEASE=2026.32.0) only
+      # deployments whose release tag matches are synced; other sites are left
+      # for a different branch/run. Empty means sync everything.
+      ONLY_RELEASE: "{{.ONLY_RELEASE}}"
     cmds:
       - |
         if [ -z "{{.SKIP}}" ]; then

--- a/infrastructure/dpladm/bin/sync-site.sh
+++ b/infrastructure/dpladm/bin/sync-site.sh
@@ -224,6 +224,24 @@ function getSiteAutogenerateRoutes {
     echo "${autogenerateRoutes}"
 }
 
+# Decides whether a deployment with the given release tag should be synced.
+#
+# When ONLY_RELEASE is empty (the default) every deployment is synced, which
+# preserves the original behaviour. When ONLY_RELEASE is set we only sync
+# deployments whose release tag matches it exactly. This lets us push a single
+# release from a release branch (eg. ONLY_RELEASE=2026.32.0) while leaving sites
+# pinned to another release to be deployed from their own branch.
+function releaseSelected {
+    local tag="${1}"
+    if [[ -z "${ONLY_RELEASE}" ]]; then
+        return 0
+    fi
+    if [[ "${tag}" == "${ONLY_RELEASE}" ]]; then
+        return 0
+    fi
+    return 1
+}
+
 if [[ -z "${SITES_CONFIG:-}" ]]; then
     print_usage "SITES_CONFIG"
 fi
@@ -234,6 +252,10 @@ fi
 
 # Default to the main branch.
 BRANCH=${BRANCH:-main}
+
+# Optional filter. When set, only deployments whose release tag matches this
+# value are synced (see releaseSelected). Empty means "sync everything".
+ONLY_RELEASE=${ONLY_RELEASE:-}
 
 if [[ ! -f "${SITES_CONFIG}" ]]; then
     echo "Could not find the file ${SITES_CONFIG}"
@@ -274,8 +296,16 @@ failOnErr $? "${nodeVersion}"
 set -o errexit
 
 # Synchronise the sites environment repository.
-syncEnvRepo "${SITE}" "${releaseTag}" "${BRANCH}" "${siteImageRepository}" "${siteReleaseImageName}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}" "${diskSize}" "${phpVersionMain}" "${nodeVersion}" "${primaryGoSubDomain}" "${secondaryGoSubDomains}" "${goRelease}"
+if releaseSelected "${releaseTag}"; then
+    syncEnvRepo "${SITE}" "${releaseTag}" "${BRANCH}" "${siteImageRepository}" "${siteReleaseImageName}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}" "${diskSize}" "${phpVersionMain}" "${nodeVersion}" "${primaryGoSubDomain}" "${secondaryGoSubDomains}" "${goRelease}"
+else
+    echo "Skipping ${SITE} ${BRANCH} deployment: release '${releaseTag}' does not match ONLY_RELEASE='${ONLY_RELEASE}'."
+fi
 
-if [ "${plan}" = "webmaster" ] && [ "${BRANCH}" = "main" ]; then
-    syncEnvRepo "${SITE}" "${wmReleaseTag}" "moduletest" "${siteImageRepository}" "${siteReleaseImageName}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}" "${diskSize}" "${phpVersionModuletest}"
+if [ "${plan}" = "webmaster" ]; then
+    if releaseSelected "${wmReleaseTag}"; then
+        syncEnvRepo "${SITE}" "${wmReleaseTag}" "moduletest" "${siteImageRepository}" "${siteReleaseImageName}" "${autogenerateRoutes}" "${primaryDomain}" "${secondaryDomains}" "${diskSize}" "${phpVersionModuletest}"
+    else
+        echo "Skipping ${SITE} moduletest deployment: release '${wmReleaseTag}' does not match ONLY_RELEASE='${ONLY_RELEASE}'."
+    fi
 fi

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -80,7 +80,6 @@ sites:
     # TODO: Remove this once the the Adgangsplatformen OpenID client used here
     # has been updated to use the primary domain.
     autogenerateRoutes: true
-    moduletest-dpl-cms-release: 2026.26.2
     # This site is a webmaster site but we usually want the latest release
     # deployed to production. Our YAML handling chokes on duplicates to we
     # follow the default release plan and update the module test site manually.
@@ -91,7 +90,6 @@ sites:
     description: "Et site hvor bibliotekerne kan teste"
     primary-domain: bibliotek-test.dplplat02.dpl.reload.dk
     plan: webmaster
-    go-release: 2026.26.2
     deploy_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvhy79hHjLcQJCcMNwci1Q/P/O2LwD4IzBVfkmRGKom
     diskSize: 5
     <<: *webmasters-on-weekly-release-cycle

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -27,9 +27,9 @@ sites:
     releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
     releaseImageName: dpl-cms-source
     plan: webmaster
-    dpl-cms-release: 2026.29.0-test.0
-    moduletest-dpl-cms-release: 2026.26.2
-    go-release: 2026.29.0-test.0
+    dpl-cms-release: 2026.32.0
+    moduletest-dpl-cms-release: 2026.32.0
+    go-release: 2026.32.0
     php-version: 8.4
     node-version: 24
     diskSize: 20
@@ -45,9 +45,9 @@ sites:
     releaseImageName: dpl-cms-source
     primary-domain: customizable.dplplat02.dpl.reload.dk
     plan: webmaster
-    dpl-cms-release: 2026.26.2
-    moduletest-dpl-cms-release: 2026.26.2
-    go-release: 2026.26.2
+    dpl-cms-release: 2026.32.0
+    moduletest-dpl-cms-release: 2026.32.0
+    go-release: 2026.32.0
     php-version: 8.4
     node-version: 24
     diskSize: 20

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -17,17 +17,6 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   go-release: 2026.24.2
   php-version: 8.4
   node-version: 24
-x-early-26: &early-26
-  # This release cycle releases the newest release, which has been
-  # tested on webmaster moduletests in the previous week, on to
-  # production
-  releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
-  releaseImageName: dpl-cms-source
-  dpl-cms-release: 2026.26.2
-  moduletest-dpl-cms-release: 2026.26.2
-  go-release: 2026.26.2
-  php-version: 8.4
-  node-version: 24
 sites:
   # Site objects are indexed by a unique key that must be a valid lagoon, and
   # github project name. That is, alphanumeric and dashes.
@@ -149,7 +138,7 @@ sites:
     autogenerateRoutes: "redirect"
     plan: webmaster
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   aarhus:
     name: "Aarhus Kommunes Biblioteker"
     description: "The library site for Aarhus"
@@ -160,7 +149,7 @@ sites:
       - aakb.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   aero:
     name: "Ærø Folkebibliotek"
     description: "The library site for Ærø"
@@ -496,7 +485,7 @@ sites:
       - herningbib.dk
     autogenerateRoutes: true
     plan: webmaster
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
     diskSize: 20
   hillerod:
     name: "Hillerød Bibliotekerne"
@@ -628,7 +617,7 @@ sites:
       - varnish.main.kobenhavn.dplplat02.dpl.reload.dk
     plan: webmaster
     deploy_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaTkDvjLW/b2qVj8FIvtX9x3TxFFZTENn+w2CFELeoC"
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
     diskSize: 20
   koge:
     name: "KøgeBibliotekerne"
@@ -794,7 +783,7 @@ sites:
       - odensebib.dk
     autogenerateRoutes: true
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   odsherred:
     name: "Odsherred Bibliotek og Kulturhuse"
     description: "The library site for Odsherred"
@@ -898,7 +887,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   skanderborg:
     name: "Skanderborg Bibliotek"
     description: "The library site for Skanderborg"
@@ -940,7 +929,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   soro:
     name: "Sorø Bibliotek"
     description: "The library site for Sorø"
@@ -981,7 +970,7 @@ sites:
     autogenerateRoutes: true
     plan: webmaster
     diskSize: 20
-    <<: *early-26
+    <<: *webmasters-on-weekly-release-cycle
   svendborg:
     name: "Svendborg Bibliotek"
     description: "The library site for Svendborg"

--- a/infrastructure/environments/dplplat01/sites.yaml
+++ b/infrastructure/environments/dplplat01/sites.yaml
@@ -2,8 +2,8 @@
 x-defaults: &default-release-image-source
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: 2026.26.2
-  go-release: 2026.26.2
+  dpl-cms-release: 2026.32.0
+  go-release: 2026.32.0
   php-version: 8.4
   node-version: 24
 x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
@@ -12,9 +12,9 @@ x-webmasters-on-weekly-release-cycle: &webmasters-on-weekly-release-cycle
   # production
   releaseImageRepository: ghcr.io/danskernesdigitalebibliotek
   releaseImageName: dpl-cms-source
-  dpl-cms-release: 2026.24.2
-  moduletest-dpl-cms-release: 2026.26.2
-  go-release: 2026.24.2
+  dpl-cms-release: 2026.26.2
+  moduletest-dpl-cms-release: 2026.32.0
+  go-release: 2026.26.2
   php-version: 8.4
   node-version: 24
 sites:


### PR DESCRIPTION
#### What does this PR do?

Prepare site file for 2026.32 release and add ONLY_RELEASE flag to better handle releasing only one version at a time.
