### PR TITLE
attempt to get rid of MySQL has gone away error

### DIFF
--- a/gitops/dplplat02/mariadb-10-6-22-production-1/templates/mariadb-server.yaml
+++ b/gitops/dplplat02/mariadb-10-6-22-production-1/templates/mariadb-server.yaml
@@ -32,8 +32,8 @@ spec:
     innodb_autoinc_lock_mode=1
     binlog_format=row
     max_connections=1500
-    wait_timeout=600
-    interactive_timeout = 600
+    wait_timeout=1600
+    interactive_timeout=800
     transaction_isolation="READ-COMMITTED"
     collation_server="LATIN1_SWEDISH_CI"
     character_set_server="LATIN1"

--- a/gitops/dplplat02/mariadb-10-6-22-production-1/templates/mariadb-server.yaml
+++ b/gitops/dplplat02/mariadb-10-6-22-production-1/templates/mariadb-server.yaml
@@ -33,6 +33,8 @@ spec:
     binlog_format=row
     max_connections=1500
     wait_timeout=1600
+    max_allowed_packet=256M
+    net_read_timeout=45
     interactive_timeout=800
     transaction_isolation="READ-COMMITTED"
     collation_server="LATIN1_SWEDISH_CI"


### PR DESCRIPTION
#### What does this PR do?
This is an attept to solve the issue surrounding the "MySQL has gone away" error as reported here https://reload.zulipchat.com/#narrow/channel/355725-DDF---Drift/topic/MySQL.20server.20has.20gone.20away/with/615781078

#### Should this be tested by the reviewer and how?


#### Any specific requests for how the PR should be reviewed?


#### What are the relevant tickets?
